### PR TITLE
[FEAT]: 카테고리 탭 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,19 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com', // 실제 이미지 호스팅 사이트
+      },
+      {
+        protocol: 'https',
+        hostname: 'placehold.co', // 더미 이미지 호스팅 사이트
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/src/app/category/page.tsx
+++ b/src/app/category/page.tsx
@@ -1,0 +1,5 @@
+import Category from '@/components/category';
+
+export default function CategoryPage() {
+  return <Category />;
+}

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,0 +1,14 @@
+import { getProductById } from '@/components/product/product-service';
+import { ProductDetail } from '@/components/product/product-detail';
+
+// id 파라미터를 받아 서버 사이드에서 상품 데이터를 조회하고, 결과를 UI 컴포넌트(ProductDetail)에 전달하는 상품 상세 페이지
+interface PageProps {
+  params: { id: string };
+}
+
+export default async function ProductDetailPage({ params }: PageProps) {
+  const resolvedParams = await Promise.resolve(params);
+  const product = await getProductById(resolvedParams.id);
+
+  return <ProductDetail product={product} />;
+}

--- a/src/app/products/[id]/page.tsx
+++ b/src/app/products/[id]/page.tsx
@@ -1,0 +1,22 @@
+import {
+  getProductsByCategoryId,
+  getCategoryTitle,
+} from '@/components/product/product-service';
+import { ProductList } from '@/components/product/product-list';
+
+interface PageProps {
+  params: { id: string };
+}
+
+// 상품 데이터와 페이지 제목을 조회한 뒤, UI 컴포넌트(ProductList)에 완성된 데이터만 전달하는 목록 페이지.
+
+export default async function ProductListPage({ params }: PageProps) {
+  const resolvedParams = await Promise.resolve(params);
+  // 서비스 함수 호출
+  const [products, title] = await Promise.all([
+    getProductsByCategoryId(resolvedParams.id),
+    getCategoryTitle(resolvedParams.id),
+  ]);
+
+  return <ProductList products={products} title={title} />;
+}

--- a/src/components/category/category-content-list.tsx
+++ b/src/components/category/category-content-list.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+// 카테고리별 섹션을 렌더링하고, 각 섹션 내부에 하위 카테고리 리스트를 그리드 형태로 보여주는 컴포넌트
+
+import { memo } from 'react';
+import { Category } from '@/mocks/category-data';
+import { SubCategoryItem } from './subcategory-item';
+
+export const CategoryContentList = memo(function CategoryContentList({
+  categories,
+}: {
+  categories: Category[];
+}) {
+  return (
+    <>
+      {categories.map((category) => (
+        <section
+          key={category.id}
+          id={category.id}
+          className="mb-8 scroll-mt-0"
+        >
+          <h2 className="sticky top-0 z-10 mb-3 border-b border-gray-100 bg-white py-3 text-sm font-bold text-gray-900">
+            {category.name}
+          </h2>
+          <div className="grid grid-cols-3 gap-x-2 gap-y-4">
+            {category.subCategories.map((sub) => (
+              <SubCategoryItem
+                key={sub.id}
+                label={sub.name}
+                imageUrl={sub.imageUrl}
+                href={`/products/${sub.id}`}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </>
+  );
+});

--- a/src/components/category/category-tab.tsx
+++ b/src/components/category/category-tab.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils';
+
+// 카테고리 선택용 탭 버튼 컴포넌트(활성/비활성)
+interface CategoryTabProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isActive: boolean;
+  label: string;
+}
+
+export function CategoryTab({
+  isActive,
+  label,
+  className,
+  ...props
+}: CategoryTabProps) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'flex h-14 w-full cursor-pointer items-center justify-center text-sm transition-colors duration-200',
+
+        isActive
+          ? 'bg-white font-bold text-black'
+          : 'bg-transparent text-gray-500 hover:bg-gray-100/50',
+      )}
+      {...props}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/components/category/index.tsx
+++ b/src/components/category/index.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { CATEGORIES } from '@/mocks/category-data';
+import { useScrollSpy } from './use-scroll-spy';
+import { CategoryTab } from './category-tab';
+import { CategoryContentList } from './category-content-list';
+import SearchBar from '@/components/search-bar';
+
+// 사용자의 스크롤 위치에 따라 사이드바의 활성 탭을 자동으로 변경하고(Scroll Spy), 탭을 클릭하면 해당 콘텐츠 위치로 이동.
+export default function Category() {
+  const categoryIds = CATEGORIES.map((c) => c.id);
+  const { activeId, scrollToId, containerRef } = useScrollSpy(categoryIds);
+  const sidebarRef = useRef<HTMLUListElement>(null);
+
+  useEffect(() => {
+    if (!activeId || !sidebarRef.current) return;
+    const activeTab = document.getElementById(`tab-${activeId}`);
+    if (activeTab) {
+      activeTab.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+        inline: 'center',
+      });
+    }
+  }, [activeId]);
+
+  return (
+    <div className="flex h-screen w-full flex-col bg-white">
+      <header className="z-20 flex flex-shrink-0 items-center border-b bg-white px-4 py-3">
+        <SearchBar />
+      </header>
+
+      <div className="flex flex-1 overflow-hidden">
+        <nav className="scrollbar-hide z-10 w-24 flex-shrink-0 overflow-y-auto bg-gray-50 pb-20">
+          <ul ref={sidebarRef}>
+            {CATEGORIES.map((category) => (
+              <li key={category.id} id={`tab-${category.id}`}>
+                <CategoryTab
+                  label={category.name}
+                  isActive={activeId === category.id}
+                  onClick={() => scrollToId(category.id)}
+                />
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <main
+          ref={containerRef}
+          className="flex-1 overflow-y-auto bg-white pb-32"
+        >
+          <div className="px-4 pt-4">
+            <CategoryContentList categories={CATEGORIES} />
+          </div>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/src/components/category/subcategory-item.tsx
+++ b/src/components/category/subcategory-item.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { cn } from '@/lib/utils';
+
+// 하위 카테고리 아이템 컴포넌트.
+
+interface SubCategoryItemProps {
+  label: string;
+  imageUrl: string;
+  href: string;
+  className?: string;
+}
+
+export function SubCategoryItem({
+  label,
+  imageUrl,
+  href,
+  className,
+}: SubCategoryItemProps) {
+  return (
+    <Link
+      href={href}
+      className={cn(
+        'flex flex-col items-center gap-2 rounded-lg p-2 transition-colors hover:bg-gray-50',
+        className,
+      )}
+    >
+      <div className="relative aspect-square w-full overflow-hidden rounded-md bg-gray-100 shadow-sm">
+        <Image
+          src={imageUrl}
+          alt={label}
+          fill
+          className="object-cover transition-transform duration-300 hover:scale-110"
+          sizes="(max-width: 768px) 33vw, 20vw"
+          loading="lazy"
+        />
+      </div>
+      <span className="text-center text-xs font-medium break-keep text-gray-700">
+        {label}
+      </span>
+    </Link>
+  );
+}

--- a/src/components/category/use-scroll-spy.ts
+++ b/src/components/category/use-scroll-spy.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useCallback, useRef, useTransition } from 'react';
+
+// 현재 보고 있는 카테고리 탭을 자동으로 활성화하고, 탭 클릭시 해당 섹션으로 이동하는 커스텀 훅.
+
+export function useScrollSpy(ids: string[]) {
+  const [activeId, setActiveId] = useState<string>(ids[0]);
+  const [isPending, startTransition] = useTransition();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isClickScrolling = useRef(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const scrollToId = useCallback((id: string) => {
+    isClickScrolling.current = true;
+    startTransition(() => {
+      setActiveId(id);
+    });
+
+    const element = document.getElementById(id);
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => {
+        isClickScrolling.current = false;
+      }, 1000); // 모바일 고려.
+    }
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (observerRef.current) observerRef.current.disconnect();
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        if (isClickScrolling.current) return;
+
+        const visibleSection = entries.reduce(
+          (max, entry) => {
+            return entry.isIntersecting &&
+              entry.intersectionRect.height > max.height
+              ? { height: entry.intersectionRect.height, id: entry.target.id }
+              : max;
+          },
+          { height: 0, id: '' },
+        );
+
+        if (visibleSection.id) {
+          setActiveId((prev) =>
+            prev === visibleSection.id ? prev : visibleSection.id,
+          );
+        }
+      },
+      {
+        root: container,
+        rootMargin: '-50px 0px -90% 0px',
+        threshold: [0, 0.01, 0.1, 0.5],
+      },
+    );
+
+    ids.forEach((id) => {
+      const element = document.getElementById(id);
+      if (element) observerRef.current?.observe(element);
+    });
+
+    return () => {
+      observerRef.current?.disconnect();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [ids]);
+
+  return { activeId, scrollToId, containerRef };
+}

--- a/src/components/product/index.tsx
+++ b/src/components/product/index.tsx
@@ -1,0 +1,4 @@
+export { ProductList } from './product-list';
+export { ProductDetail } from './product-detail';
+export { ProductCard } from './product-card';
+export { ProductGrid } from './product-grid';

--- a/src/components/product/product-card.tsx
+++ b/src/components/product/product-card.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { Product } from '@/mocks/product-data';
+import { cn } from '@/lib/utils';
+
+// 카드 UI 컴포넌트, 클릭 시 상세 페이지로 이동함.
+interface ProductCardProps {
+  product: Product;
+}
+
+export function ProductCard({ product }: ProductCardProps) {
+  return (
+    <Link href={`/product/${product.id}`} className="group block">
+      <div className="relative aspect-[3/4] w-full overflow-hidden rounded-lg bg-gray-100">
+        <Image
+          src={product.imageUrl}
+          alt={product.name}
+          fill
+          className={cn(
+            'object-cover transition-transform duration-300 group-hover:scale-105',
+            product.isSoldOut && 'opacity-50 grayscale',
+          )}
+          sizes="(max-width: 768px) 50vw, (max-width: 1024px) 33vw, 25vw"
+          loading="lazy"
+        />
+
+        {product.isSoldOut && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/10">
+            <span className="rounded bg-black/70 px-2 py-1 text-xs font-bold text-white">
+              SOLD OUT
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-3 space-y-1">
+        <p className="text-xs font-bold text-gray-900">{product.brand}</p>
+        <h3 className="line-clamp-2 text-sm text-gray-700">{product.name}</h3>
+
+        <div className="mt-1 flex items-center gap-2">
+          <span className="text-sm font-bold text-gray-900">
+            {product.price.toLocaleString()}원
+          </span>
+          {product.discountRate && (
+            <span className="text-sm font-bold text-red-600">
+              {product.discountRate}%
+            </span>
+          )}
+        </div>
+
+        {product.originalPrice && (
+          <p className="text-xs text-gray-400 line-through">
+            {product.originalPrice.toLocaleString()}원
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/components/product/product-detail.tsx
+++ b/src/components/product/product-detail.tsx
@@ -1,0 +1,71 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { Product } from '@/mocks/product-data';
+
+interface ProductDetailProps {
+  product: Product | null;
+}
+
+export function ProductDetail({ product }: ProductDetailProps) {
+  if (!product) {
+    return (
+      <div className="flex h-[50vh] flex-col items-center justify-center gap-4">
+        <p className="text-gray-500">상품 정보를 찾을 수 없습니다.</p>
+        <Link
+          href="/category"
+          className="rounded-md bg-black px-4 py-2 text-sm font-bold text-white"
+        >
+          목록으로 돌아가기
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto min-h-screen max-w-screen-xl bg-white px-4 py-8">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
+        <div className="relative aspect-square w-full overflow-hidden rounded-lg bg-gray-100">
+          <Image
+            src={product.imageUrl}
+            alt={product.name}
+            fill
+            className="object-cover"
+            priority
+          />
+        </div>
+        <div className="flex flex-col justify-between py-2">
+          <div className="space-y-4">
+            <div>
+              <h2 className="text-sm font-bold text-gray-500">
+                {product.brand}
+              </h2>
+              <h1 className="mt-1 text-2xl font-bold text-gray-900">
+                {product.name}
+              </h1>
+            </div>
+            <div className="border-t border-b py-4">
+              <div className="flex items-center gap-3">
+                <span className="text-2xl font-bold">
+                  {product.price.toLocaleString()}원
+                </span>
+                {product.discountRate && (
+                  <span className="text-xl font-bold text-red-600">
+                    {product.discountRate}%
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
+          <div className="mt-8 flex gap-3">
+            <button className="flex-1 rounded-lg border border-gray-300 py-4 font-bold hover:bg-gray-50">
+              장바구니
+            </button>
+            <button className="flex-1 rounded-lg bg-black py-4 font-bold text-white hover:bg-gray-800">
+              구매하기
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/product/product-grid.tsx
+++ b/src/components/product/product-grid.tsx
@@ -1,0 +1,30 @@
+import { Product } from '@/mocks/product-data';
+import { ProductCard } from './product-card';
+
+// 상품 목록 데이터를 받아서 그리드 형식으로 렌더링하는 컴포넌트.
+
+interface ProductGridProps {
+  products: Product[];
+  emptyMessage?: string;
+}
+
+export function ProductGrid({
+  products,
+  emptyMessage = '등록된 상품이 없습니다.',
+}: ProductGridProps) {
+  if (products.length === 0) {
+    return (
+      <div className="flex h-60 items-center justify-center text-gray-500">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 lg:grid-cols-4">
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/product/product-list.tsx
+++ b/src/components/product/product-list.tsx
@@ -1,0 +1,32 @@
+import { Product } from '@/mocks/product-data';
+import { ProductGrid } from './product-grid';
+
+// categoryId를 받아 해당 카테고리의 이름과 상품 데이터를 필터링하여, 상단 헤더와 상품 그리드 형태로 보여주는 목록 페이지 컴포넌트
+
+interface ProductListProps {
+  products: Product[];
+  title: string;
+}
+
+export function ProductList({ products, title }: ProductListProps) {
+  return (
+    <div className="mx-auto min-h-screen max-w-screen-xl bg-white">
+      <header className="sticky top-0 z-10 flex items-center justify-center border-b bg-white px-4 py-3">
+        <h1 className="text-lg font-bold">{title}</h1>
+      </header>
+
+      <main className="p-4">
+        <div className="mb-4 flex items-center justify-between">
+          <span className="text-sm text-gray-500">
+            총 <b className="text-black">{products.length}</b>개
+          </span>
+        </div>
+
+        <ProductGrid
+          products={products}
+          emptyMessage="해당 카테고리에 등록된 상품이 없습니다."
+        />
+      </main>
+    </div>
+  );
+}

--- a/src/components/product/product-service.ts
+++ b/src/components/product/product-service.ts
@@ -1,0 +1,34 @@
+import { PRODUCTS } from '@/mocks/product-data';
+import { CATEGORIES } from '@/mocks/category-data';
+
+// 백엔드 API가 나오면 이 파일 fetch로 수정하면 됨.
+
+// 카테고리 ID로 상품 목록 가져오기
+export async function getProductsByCategoryId(categoryId: string) {
+  if (categoryId.endsWith('-all')) {
+    const parentId = categoryId.replace('-all', '');
+    return PRODUCTS.filter((p) => p.categoryId.startsWith(parentId));
+  }
+
+  // 일반 카테고리 처리
+  return PRODUCTS.filter((p) => p.categoryId === categoryId);
+}
+
+// 상품 ID로 상세 정보 가져오기
+export async function getProductById(productId: string) {
+  // ex)fetch('/api/products/${productId}')같은 방식으로 추후 백엔드 연동시 사용
+  return PRODUCTS.find((p) => p.id === productId) || null;
+}
+
+// 페이지 제목 가져오기
+export async function getCategoryTitle(categoryId: string) {
+  if (categoryId.endsWith('-all')) {
+    const parentId = categoryId.replace('-all', '');
+    const parent = CATEGORIES.find((c) => c.id === parentId);
+    return parent ? `${parent.name} 전체` : '전체 상품';
+  }
+
+  const allSubs = CATEGORIES.flatMap((c) => c.subCategories);
+  const sub = allSubs.find((s) => s.id === categoryId);
+  return sub ? sub.name : '상품 목록';
+}

--- a/src/mocks/category-data.ts
+++ b/src/mocks/category-data.ts
@@ -1,0 +1,135 @@
+export type SubCategory = {
+  id: string;
+  name: string;
+  imageUrl: string;
+};
+
+export type Category = {
+  id: string;
+  name: string;
+  subCategories: SubCategory[];
+};
+
+// 카테고리 목업 데이터.
+
+const getRealImage = (keyword: string) => {
+  const images: Record<string, string> = {
+    top: 'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=300&q=80',
+    outer:
+      'https://images.unsplash.com/photo-1551028919-ac6635f0e5c9?auto=format&fit=crop&w=300&q=80',
+    pants:
+      'https://images.unsplash.com/photo-1542272454315-4c01d7abdf4a?auto=format&fit=crop&w=300&q=80',
+    skirt:
+      'https://images.unsplash.com/photo-1583496661160-fb5886a0aaaa?auto=format&fit=crop&w=300&q=80',
+    shoes:
+      'https://images.unsplash.com/photo-1549298916-b41d501d3772?auto=format&fit=crop&w=300&q=80',
+    bag: 'https://images.unsplash.com/photo-1584917865442-de89df76afd3?auto=format&fit=crop&w=300&q=80',
+    hat: 'https://images.unsplash.com/photo-1533867617858-e7b97e0605df?auto=format&fit=crop&w=300&q=80',
+    default:
+      'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?auto=format&fit=crop&w=300&q=80',
+  };
+  return images[keyword] || images.default;
+};
+
+export const CATEGORIES: Category[] = [
+  {
+    id: 'top',
+    name: '상의',
+    subCategories: [
+      { id: 'top-all', name: '상의 전체', imageUrl: getRealImage('top') },
+      { id: 'top-1', name: '니트/스웨터', imageUrl: getRealImage('top') },
+      { id: 'top-2', name: '후드 티셔츠', imageUrl: getRealImage('top') },
+      { id: 'top-3', name: '맨투맨/스웨트', imageUrl: getRealImage('top') },
+      { id: 'top-4', name: '긴소매 티셔츠', imageUrl: getRealImage('top') },
+      { id: 'top-5', name: '셔츠/블라우스', imageUrl: getRealImage('top') },
+      { id: 'top-6', name: '반소매 티셔츠', imageUrl: getRealImage('top') },
+    ],
+  },
+  {
+    id: 'outer',
+    name: '아우터',
+    subCategories: [
+      { id: 'outer-all', name: '아우터 전체', imageUrl: getRealImage('outer') },
+      {
+        id: 'outer-1',
+        name: '겨울 싱글 코트',
+        imageUrl: getRealImage('outer'),
+      },
+      {
+        id: 'outer-2',
+        name: '겨울 더블 코트',
+        imageUrl: getRealImage('outer'),
+      },
+      {
+        id: 'outer-3',
+        name: '숏패딩/헤비 아우터',
+        imageUrl: getRealImage('outer'),
+      },
+      {
+        id: 'outer-4',
+        name: '롱패딩/헤비 아우터',
+        imageUrl: getRealImage('outer'),
+      },
+      { id: 'outer-6', name: '재킷', imageUrl: getRealImage('outer') },
+      { id: 'outer-9', name: '카디건', imageUrl: getRealImage('outer') },
+    ],
+  },
+  {
+    id: 'pants',
+    name: '바지',
+    subCategories: [
+      { id: 'pants-all', name: '바지 전체', imageUrl: getRealImage('pants') },
+      { id: 'pants-1', name: '데님 팬츠', imageUrl: getRealImage('pants') },
+      { id: 'pants-2', name: '코튼 팬츠', imageUrl: getRealImage('pants') },
+      {
+        id: 'pants-3',
+        name: '슈트 팬츠/슬랙스',
+        imageUrl: getRealImage('pants'),
+      },
+      {
+        id: 'pants-4',
+        name: '트레이닝/조거 팬츠',
+        imageUrl: getRealImage('pants'),
+      },
+      { id: 'pants-5', name: '숏 팬츠', imageUrl: getRealImage('pants') },
+    ],
+  },
+  {
+    id: 'skirt',
+    name: '스커트',
+    subCategories: [
+      { id: 'skirt-all', name: '스커트 전체', imageUrl: getRealImage('skirt') },
+      { id: 'sk-1', name: '미니 스커트', imageUrl: getRealImage('skirt') },
+      { id: 'sk-2', name: '미디 스커트', imageUrl: getRealImage('skirt') },
+      { id: 'sk-3', name: '롱 스커트', imageUrl: getRealImage('skirt') },
+    ],
+  },
+  {
+    id: 'shoes',
+    name: '신발',
+    subCategories: [
+      { id: 'shoes-all', name: '신발 전체', imageUrl: getRealImage('shoes') },
+      { id: 'shoes-1', name: '스니커즈', imageUrl: getRealImage('shoes') },
+      { id: 'shoes-2', name: '구두', imageUrl: getRealImage('shoes') },
+      { id: 'shoes-5', name: '부츠/워커', imageUrl: getRealImage('shoes') },
+    ],
+  },
+  {
+    id: 'bag',
+    name: '가방',
+    subCategories: [
+      { id: 'bag-all', name: '가방 전체', imageUrl: getRealImage('bag') },
+      { id: 'bag-1', name: '백팩', imageUrl: getRealImage('bag') },
+      { id: 'bag-3', name: '숄더/토트 백', imageUrl: getRealImage('bag') },
+    ],
+  },
+  {
+    id: 'hat',
+    name: '모자',
+    subCategories: [
+      { id: 'hat-all', name: '모자 전체', imageUrl: getRealImage('hat') },
+      { id: 'hat-1', name: '캡/야구 모자', imageUrl: getRealImage('hat') },
+      { id: 'hat-3', name: '비니', imageUrl: getRealImage('hat') },
+    ],
+  },
+];

--- a/src/mocks/product-data.ts
+++ b/src/mocks/product-data.ts
@@ -1,0 +1,65 @@
+export type Product = {
+  id: string;
+  name: string;
+  brand: string;
+  price: number;
+  originalPrice?: number;
+  discountRate?: number;
+  imageUrl: string;
+  categoryId: string;
+  isSoldOut?: boolean;
+};
+
+// 브랜드, 가격, 할인율, 품절 여부 등이 무작위로 설정된 테스트용 상품 목업 데이터를 자동 생성하는 코드
+const REAL_PRODUCT_IMAGES = [
+  'https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=500&q=80',
+  'https://images.unsplash.com/photo-1551028919-ac6635f0e5c9?auto=format&fit=crop&w=500&q=80',
+  'https://images.unsplash.com/photo-1606107557195-0e29a4b5b4aa?auto=format&fit=crop&w=500&q=80',
+  'https://images.unsplash.com/photo-1542272454315-4c01d7abdf4a?auto=format&fit=crop&w=500&q=80',
+  'https://images.unsplash.com/photo-1434389677669-e08b4cac3105?auto=format&fit=crop&w=500&q=80',
+  'https://images.unsplash.com/photo-1618354691373-d851c5c3a990?auto=format&fit=crop&w=500&q=80',
+];
+
+function getRandomImage() {
+  return REAL_PRODUCT_IMAGES[
+    Math.floor(Math.random() * REAL_PRODUCT_IMAGES.length)
+  ];
+}
+
+function generateDummyProducts(
+  categoryId: string,
+  count: number,
+  baseName: string,
+): Product[] {
+  return Array.from({ length: count }).map((_, i) => {
+    const isDiscount = Math.random() > 0.4;
+    const price = Math.floor(Math.random() * 20 + 3) * 10000 - 100; // 29,900 ~
+
+    return {
+      id: `${categoryId}-${i}`,
+      name: `${baseName} 에센셜 아이템 ${i + 1}`,
+      brand: ['MUSINSA STANDARD', 'NIKE', 'ADIDAS', 'LEE', 'COVERNAT'][
+        Math.floor(Math.random() * 5)
+      ],
+      price: price,
+      originalPrice: isDiscount ? Math.floor(price * 1.3) : undefined,
+      discountRate: isDiscount
+        ? Math.floor(Math.random() * 30 + 10)
+        : undefined,
+      imageUrl: getRandomImage(),
+      categoryId: categoryId,
+      isSoldOut: Math.random() > 0.9,
+    };
+  });
+}
+
+export const PRODUCTS: Product[] = [
+  ...generateDummyProducts('top-1', 15, '프리미엄 니트'),
+  ...generateDummyProducts('top-2', 12, '오버핏 후드'),
+  ...generateDummyProducts('outer-1', 10, '캐시미어 코트'),
+  ...generateDummyProducts('outer-3', 10, '덕다운 패딩'),
+  ...generateDummyProducts('pants-1', 15, '와이드 데님'),
+  ...generateDummyProducts('shoes-1', 12, '데일리 스니커즈'),
+  ...generateDummyProducts('bag-1', 8, '미니 크로스백'),
+  ...generateDummyProducts('hat-1', 10, '베이직 캡'),
+];


### PR DESCRIPTION
## 📝 개요

- 상품 목록/ 상세 페이지와 스크롤 스파이 기능이 적용한 카테고리 메인페이지 구현
- 백엔드 API 연동 전까지 사용할 목업 데이터와 서비스 로직 구현.
- 관련 이슈 번호: Closes #7 

## 🚀 주요 변경 사항

- [x] 목업데이터 및 서비스 레이어 구축
- [x] 상품 도메인 UI 구현
- [x] 카테고리 기능 구현
- [x] 페이지 라우팅 및 외부 이미지 도메인 허용.

## 📸 스크린샷 (선택)
- 참고 : 화면에 보이는 카테고리 상세 페이지 이미지는 랜덤.

| 카테고리 메인 페이지 | 카테고리 상세 페이지 | 상품 상세 페이지 |
| :------------------: | :------------------: | :--------------: |
| <img src="https://github.com/user-attachments/assets/c0023b86-5216-453f-ad2a-a8d18c7b7098" width="300" /> | <img src="https://github.com/user-attachments/assets/03c00b55-1488-42a4-a0a7-698fd2baa2fc" width="300" /> | <img src="https://github.com/user-attachments/assets/d4956b92-d9d2-4648-a5f5-2041095155e0" width="300" /> |

## ✅ 체크리스트

- [x] 빌드 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 console.log는 제거했나요?