### PR TITLE
[FEAT]: 상품 상세 사이즈 탭 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-progress": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-progress':
+        specifier: ^1.1.8
+        version: 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
@@ -488,6 +491,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
@@ -573,6 +585,32 @@ packages:
 
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-progress@1.1.8':
+    resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2754,6 +2792,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -2836,6 +2880,25 @@ snapshots:
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-progress@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/src/app/@modal/(.)search/page.tsx
+++ b/src/app/@modal/(.)search/page.tsx
@@ -2,7 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import SearchBar from '@/components/search-bar';
+import SearchBar from '@/components/search-bar/search-bar';
 import Modal from '@/components/ui/search-modal';
 
 export default function InterceptedSearchPage() {

--- a/src/app/product/[id]/layout.tsx
+++ b/src/app/product/[id]/layout.tsx
@@ -3,16 +3,12 @@ import { Metadata } from 'next';
 import { getProductById } from '@/components/product/product-service';
 import { ScrollToTop } from '@/components/ui/scroll-to-top';
 
-import { PRODUCTS } from '@/mocks/product-data';
-
 import {
   ProductImageSlider,
   ProductInfo,
   ProductBottomBar,
   CompactProductHeader,
   ProductTab,
-  ProductNotice,
-  RecommendedProductsCarousel,
   ProductInteractionProvider,
   ProductStickyContainer,
   ProductHeader,
@@ -48,12 +44,6 @@ export default async function ProductLayout({ children, params }: LayoutProps) {
 
   if (!product) notFound();
 
-  // 현재 상품 제외하고 6개 추천
-  const recommendedProducts = PRODUCTS.filter((p) => p.id !== product.id).slice(
-    0,
-    6,
-  );
-
   return (
     <div className="relative min-h-screen bg-white pb-32">
       <ProductInteractionProvider key={id}>
@@ -70,14 +60,6 @@ export default async function ProductLayout({ children, params }: LayoutProps) {
         >
           {/* 탭별 페이지가 렌더링되는 부분 => 설명/사이즈/문의/소재:리뷰 */}
           {children}
-
-          {/* 하단 공통 영역 */}
-          <div className="space-y-12 border-t border-gray-100 pt-10">
-            <ProductNotice />
-            <div className="pt-4">
-              <RecommendedProductsCarousel products={recommendedProducts} />
-            </div>
-          </div>
         </ProductStickyContainer>
 
         {/* 플로팅 요소 */}

--- a/src/app/product/[id]/size/page.tsx
+++ b/src/app/product/[id]/size/page.tsx
@@ -1,8 +1,36 @@
-export default function ProductSizePage() {
+import SizeInfo from '@/components/product/size/size-info';
+import SizeGuideSection from '@/components/product/size/size-guide-section';
+import { fetchUserBodyInfo, fetchSizeAnalysis } from '@/mocks/size';
+
+interface ProductSizePageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function ProductSizePage({
+  params,
+}: ProductSizePageProps) {
+  const { id: productId } = await params;
+  const productType = 'top';
+  const userInfo = await fetchUserBodyInfo();
+  const analysisData = userInfo
+    ? await fetchSizeAnalysis(productId, userInfo.height, userInfo.weight)
+    : null;
+
   return (
-    <div className="rounded-lg bg-gray-50 py-20 text-center text-gray-500">
-      <p>사이즈 영역입니다.</p>
-      <p className="mt-2 text-sm">이곳에 사이즈 컴포넌트가 들어갑니다.</p>
+    <div className="font-pretendard flex flex-col gap-10 px-4 py-8 pb-20">
+      {/* 상단 실측 정보 */}
+      <SizeInfo />
+
+      <hr className="border-gray-100" />
+
+      {/* 사이즈 가이드 섹션 */}
+      <section className="space-y-4">
+        <SizeGuideSection
+          productType={productType}
+          userInfo={userInfo}
+          analysisData={analysisData}
+        />
+      </section>
     </div>
   );
 }

--- a/src/components/product/descriptions/product-description.tsx
+++ b/src/components/product/descriptions/product-description.tsx
@@ -4,10 +4,18 @@ import { useState } from 'react';
 import Image from 'next/image';
 import { Product } from '@/mocks/product-data';
 import { Button } from '@/components/ui/button';
+import { ProductNotice } from '../product-notice';
+import { RecommendedProductsCarousel } from '../recommended-products-carousel';
+import { PRODUCTS } from '@/mocks/product-data';
 
 // 상품 설명 섹션 컴포넌트, 상세 이미지, 펼치기
 
 export function ProductDescription({ product }: { product: Product }) {
+  // 현재 상품 제외하고 6개 추천
+  const recommendedProducts = PRODUCTS.filter((p) => p.id !== product.id).slice(
+    0,
+    6,
+  );
   const [isExpanded, setIsExpanded] = useState(false);
 
   // 8.4.1 (4) 펼치면 상세 이미지 10개
@@ -42,6 +50,14 @@ export function ProductDescription({ product }: { product: Product }) {
           펼치기 <span className="text-xs">▼</span>
         </Button>
       )}
+
+      {/* 하단 공통 영역 */}
+      <div className="space-y-12 border-t border-gray-100 pt-10">
+        <ProductNotice />
+        <div className="pt-4">
+          <RecommendedProductsCarousel products={recommendedProducts} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/product/size/my-size.tsx
+++ b/src/components/product/size/my-size.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { Ruler, Edit2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { UserBodyInfo } from '@/mocks/size';
+
+interface MySizeProps {
+  userInfo: UserBodyInfo;
+  productType: 'top' | 'bottom' | 'shoes';
+}
+
+// 자세히보기 버튼 눌렀을 때 나오는 내 사이즈 정보 컴포넌트
+
+export default function MySize({ userInfo, productType }: MySizeProps) {
+  // 제품 유형에 따른 유저 사이즈 텍스트 반환
+  const getUserSizeText = () => {
+    switch (productType) {
+      case 'top':
+        return userInfo.usualTopSize;
+      case 'bottom':
+        return userInfo.usualBottomSize;
+      case 'shoes':
+        return userInfo.usualShoeSize;
+      default:
+        return '';
+    }
+  };
+
+  return (
+    <div className="mt-8 flex flex-col gap-12">
+      <h3 className="text-center text-xl font-bold text-gray-900">
+        내 사이즈 정보
+      </h3>
+      <Card className="border border-gray-100 bg-white shadow-sm">
+        <CardContent className="flex items-center justify-between px-6 py-5">
+          <div className="flex items-center gap-12">
+            <div className="bg-ongil-mint flex h-10 w-10 shrink-0 items-center justify-center rounded-full">
+              <Ruler className="h-5 w-5" />
+            </div>
+            <div className="text-xl font-bold text-gray-900">
+              {userInfo.height}cm / {userInfo.weight}kg / {getUserSizeText()}
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Button
+        variant="outline"
+        className="bg-ongil-teal w-full rounded-xl border-gray-300 py-7 text-base font-bold text-white hover:bg-[#00252a] hover:text-white"
+        onClick={() => alert('내 정보 수정 페이지로 이동')}
+      >
+        <Edit2 className="mr-2 h-5 w-5" />내 정보 수정하기
+      </Button>
+    </div>
+  );
+}

--- a/src/components/product/size/similar-user-table.tsx
+++ b/src/components/product/size/similar-user-table.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { Info } from 'lucide-react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { SizeAnalysisResult } from '@/mocks/size';
+
+interface SimilarUserTableProps {
+  similarUsersSample: SizeAnalysisResult['similarUsersSample'];
+}
+
+// 고객과 체형이 유사한 다른 고객들의 사이즈 정보 테이블 컴포넌트
+
+export function SimilarUserTable({
+  similarUsersSample,
+}: SimilarUserTableProps) {
+  return (
+    <div className="animate-in fade-in slide-in-from-top-2 duration-300">
+      <div className="mb-3 flex items-start gap-2 rounded-md bg-gray-50 p-3 text-xs text-gray-500">
+        <Info className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400" />
+        <span>
+          고객님과 체형(키 ±5cm, 몸무게 ±5kg)이 유사한 고객들이
+          <br />
+          실제 구매하고 만족한 사이즈 정보입니다.
+        </span>
+      </div>
+      <div className="mb-12 overflow-hidden rounded-lg border border-gray-200">
+        <Table>
+          <TableHeader className="bg-gray-50">
+            <TableRow>
+              <TableHead className="w-1/3 text-center text-xs">키</TableHead>
+              <TableHead className="w-1/3 text-center text-xs">
+                몸무게
+              </TableHead>
+              <TableHead className="w-1/3 text-center text-xs">
+                구매 사이즈
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {similarUsersSample.length > 0 ? (
+              similarUsersSample.map((user, idx) => (
+                <TableRow key={`${user.id}-${idx}`}>
+                  <TableCell className="text-center text-sm font-medium">
+                    {user.height}cm
+                  </TableCell>
+                  <TableCell className="text-center text-sm text-gray-600">
+                    {user.weight}kg
+                  </TableCell>
+                  <TableCell className="text-ongil-teal text-center text-sm font-bold">
+                    {user.size}
+                  </TableCell>
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={3}
+                  className="h-24 text-center text-sm text-gray-500"
+                >
+                  데이터가 충분하지 않습니다.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/product/size/size-guide-section.tsx
+++ b/src/components/product/size/size-guide-section.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { UserBodyInfo, SizeAnalysisResult } from '@/mocks/size';
+import { SimilarUserTable } from './similar-user-table';
+import MySize from './my-size';
+
+interface SizeGuideSectionProps {
+  productType: 'top' | 'bottom' | 'shoes';
+  userInfo: UserBodyInfo | null;
+  analysisData: SizeAnalysisResult | null;
+}
+
+// 사이즈 가이드 섹션 컴포넌트(사이즈 선택 가이드 그래프, 자세히 보기 눌렀을 때 나오는 표와 내 사이즈 정보)
+
+export default function SizeGuideSection({
+  productType,
+  userInfo,
+  analysisData,
+}: SizeGuideSectionProps) {
+  const [isDetailOpen, setIsDetailOpen] = useState(false);
+  // userInfo = null; // 테스트용: 유저 정보 없는 상태
+
+  // 유저 정보가 없는 경우
+  if (!userInfo) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-200 bg-gray-50 py-10 text-center">
+        <div className="mx-auto flex max-w-xs flex-col items-center gap-4 px-4 font-bold">
+          <h3 className="pb-6 text-xl text-gray-900">사이즈 선택 가이드</h3>
+          <p className="mb-4 font-medium text-gray-500">정보가 없습니다.</p>
+          <Button
+            variant="outline"
+            className="bg-ongil-teal w-full rounded-xl border-gray-300 py-7 text-base font-bold text-white hover:bg-[#00252a] hover:text-white"
+            onClick={() => alert('내 정보 수정 페이지로 이동')}
+          >
+            내 신체 정보 입력
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // 분석 데이터가 없는 경우
+  if (!analysisData) {
+    return null;
+  }
+
+  const { recommendedSizes, stats } = analysisData;
+
+  return (
+    <div className="flex flex-col gap-16">
+      {/* 1. 사이즈 선택 가이드 (그래프)*/}
+      <section className="space-y-10">
+        <div className="flex flex-col items-center justify-between font-bold">
+          <h3 className="pb-6 text-lg text-gray-900">사이즈 선택 가이드</h3>
+          <div className="text-xl">
+            추천 사이즈:{' '}
+            <span className="text-ongil-teal font-bold">
+              {recommendedSizes.join(', ')}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-8">
+          {stats.map((stat) => {
+            const isRecommended = recommendedSizes.includes(stat.size);
+            return (
+              <div key={stat.size} className="flex items-center gap-3 text-sm">
+                <div
+                  className={`w-8 font-bold ${isRecommended ? 'text-ongil-teal' : 'text-gray-700'}`}
+                >
+                  {stat.size}
+                </div>
+                <div className="flex-1">
+                  <Progress value={stat.ratio} className="h-2.5 bg-gray-100" />
+                </div>
+                <div className="w-12 text-right text-sm text-gray-500">
+                  {stat.count}명
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
+      <hr className="border-gray-100" />
+
+      {/* 2. 자세히 보기 (표 + 내정보 영역) */}
+
+      <section>
+        <Button
+          variant="outline"
+          className="bg-ongil-teal mt-6 w-full rounded-xl border-gray-300 py-7 text-base font-bold text-white hover:bg-[#00252a] hover:text-white"
+          onClick={() => setIsDetailOpen(!isDetailOpen)}
+          aria-expanded={isDetailOpen}
+        >
+          {isDetailOpen ? '접기' : '자세히 보기'}
+          {isDetailOpen ? (
+            <ChevronUp className="ml-2 h-4 w-4" />
+          ) : (
+            <ChevronDown className="ml-2 h-4 w-4" />
+          )}
+        </Button>
+
+        {isDetailOpen && (
+          <div className="mt-4">
+            <SimilarUserTable
+              similarUsersSample={analysisData.similarUsersSample}
+            />
+
+            <hr className="mt-4 border-gray-100" />
+
+            <MySize userInfo={userInfo} productType={productType} />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/product/size/size-info.tsx
+++ b/src/components/product/size/size-info.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Sparkles } from 'lucide-react';
+
+// AI가 생성한 이미지를 보여주는 컴포넌트 => 추후 연동 필요.
+
+export default function SizeInfo() {
+  return (
+    <div className="space-y-4">
+      <h3 className="px-4 text-lg font-bold text-gray-900">사이즈 정보</h3>
+      <div className="relative overflow-hidden rounded-xl border border-gray-100 bg-gray-50 p-6 text-center">
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <div className="rounded-full bg-white p-4 shadow-sm ring-1 ring-gray-100">
+            <Sparkles className="text-ongil-teal h-6 w-6" />
+          </div>
+          <div className="space-y-1">
+            <p className="font-semibold text-gray-900">AI 실측 사이즈 이미지</p>
+            <p className="text-sm leading-relaxed text-gray-500">
+              현재 상품의 실측 정보를 기반으로
+              <br />
+              AI가 생성한 이미지가 표시됩니다.
+            </p>
+          </div>
+        </div>
+      </div>
+      <p className="text-right text-xs text-gray-400">
+        * 측정 방법에 따라 1-3cm 오차가 있을 수 있습니다.
+      </p>
+    </div>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+import * as ProgressPrimitive from '@radix-ui/react-progress';
+
+import { cn } from '@/lib/utils';
+
+function Progress({
+  className,
+  value,
+  ...props
+}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+  return (
+    <ProgressPrimitive.Root
+      data-slot="progress"
+      className={cn(
+        'bg-primary/20 relative h-2 w-full overflow-hidden rounded-full',
+        className,
+      )}
+      {...props}
+    >
+      {/*bg-primary에서 bg-yellow-400로 변경 */}
+      <ProgressPrimitive.Indicator
+        data-slot="progress-indicator"
+        className="h-full w-full flex-1 bg-yellow-400 transition-all"
+        style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
+      />
+    </ProgressPrimitive.Root>
+  );
+}
+
+export { Progress };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,116 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("text-muted-foreground mt-4 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/src/mocks/size.ts
+++ b/src/mocks/size.ts
@@ -1,0 +1,58 @@
+// 사이즈 관련 임시 데이터.
+export type UserBodyInfo = {
+  height: number;
+  weight: number;
+  usualTopSize: string;
+  usualBottomSize: string;
+  usualShoeSize: string;
+};
+
+export type SizeAnalysisResult = {
+  recommendedSizes: string[];
+  stats: {
+    size: string;
+    count: number;
+    ratio: number;
+  }[];
+  similarUsersSample: {
+    id: string;
+    height: number;
+    weight: number;
+    size: string;
+  }[];
+};
+
+// 유저 정보 가져오기
+export async function fetchUserBodyInfo(): Promise<UserBodyInfo | null> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return {
+    height: 175,
+    weight: 70,
+    usualTopSize: 'M',
+    usualBottomSize: 'L',
+    usualShoeSize: '270',
+  };
+}
+
+// 사이즈 분석 결과 가져오기
+export async function fetchSizeAnalysis(
+  productId: string,
+  userHeight: number,
+  userWeight: number,
+): Promise<SizeAnalysisResult> {
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return {
+    recommendedSizes: ['L'],
+    stats: [
+      { size: 'L', count: 120, ratio: 60 },
+      { size: 'XL', count: 50, ratio: 25 },
+      { size: 'M', count: 30, ratio: 15 },
+    ],
+    similarUsersSample: [
+      { id: '1', height: 173, weight: 68, size: 'L' },
+      { id: '2', height: 176, weight: 72, size: 'L' },
+      { id: '3', height: 175, weight: 70, size: 'L' },
+      { id: '4', height: 178, weight: 73, size: 'XL' },
+    ],
+  };
+}


### PR DESCRIPTION
## 📝 개요

- 상품 상세 **사이즈 탭 페이지 구현**
- 관련 이슈 번호: Closes #31

---

## 🚀 주요 변경 사항

- [x] shadcn table, card, progress 추가
- [x] 사이즈 정보(추후 AI 연동 예정)
- [x] 사이즈 선택 가이드 + 사이즈 표
- [x] 내 사이즈 정보 UI 구현

---

## 📸 스크린샷

| 기능 | 화면 |
|:---:|:---:|
| 1. 사이즈 정보 | <img width="584" height="568" alt="image" src="https://github.com/user-attachments/assets/75c6579c-2808-4a28-9431-a6f32080028d" /> |
| 2. 사이즈 선택 가이드 | <img width="573" height="755" alt="image" src="https://github.com/user-attachments/assets/454ab9bb-fad0-4ab5-b081-348b5c3b32d0" /> |
| 3. 사이즈 표 | <img width="546" height="411" alt="image" src="https://github.com/user-attachments/assets/99ed94db-f807-4791-a67d-b33b0701d62d" /> |
| 4. 내 사이즈 정보 | <img width="560" height="514" alt="image" src="https://github.com/user-attachments/assets/73c6bfb0-905e-4f3e-abb9-b62ea4f3fbc2" /> |

---

## ✅ 체크리스트

- [x] 빌드 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 console.log는 제거했나요?

---

## 이슈 해결 여부
PR 본문에 `Closes #이슈번호` 라고 적으면, PR이 머지될 때 해당 이슈가 자동으로 닫힙니다.

