### PR TITLE
[FEAT]: 배송지 관리 플로우 고도화 및 마이페이지 내 정보 수정 기능 확장

### DIFF
--- a/src/app/@modal/(.)body-info/_components/wrapper.tsx
+++ b/src/app/@modal/(.)body-info/_components/wrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { BodyInfoForm } from '@/components/product/size/body-info-form';
+import BodyInfoForm from '@/components/product/size/body-info-form';
 import { UserBodyInfo } from '@/types/domain/size';
 
 // 제출성공시 모달 닫기 + 뒤로가기 처리 래퍼 컴포넌트

--- a/src/app/actions/address.ts
+++ b/src/app/actions/address.ts
@@ -53,6 +53,7 @@ export async function registerAddress(
       data,
     );
     revalidatePath('/address');
+    revalidatePath('/orders', 'layout');
     revalidatePath('/orders/checkout');
     return response;
   } catch (error) {
@@ -75,6 +76,7 @@ export async function updateAddress(
       data,
     );
     revalidatePath('/address');
+    revalidatePath('/orders', 'layout');
     return response;
   } catch (error) {
     rethrowNextError(error);
@@ -90,6 +92,7 @@ export async function deleteAddress(addressId: number): Promise<void> {
   try {
     await api.delete(`/addresses/${addressId}`);
     revalidatePath('/address');
+    revalidatePath('/orders', 'layout');
   } catch (error) {
     rethrowNextError(error);
     console.error('배송지 삭제 실패:', error);
@@ -109,6 +112,7 @@ export async function setAsDefaultAddress(
       {},
     );
     revalidatePath('/address');
+    revalidatePath('/orders', 'layout');
     return response;
   } catch (error) {
     rethrowNextError(error);

--- a/src/app/actions/address.ts
+++ b/src/app/actions/address.ts
@@ -52,7 +52,7 @@ export async function registerAddress(
       '/addresses',
       data,
     );
-    revalidatePath('/me/address');
+    revalidatePath('/address');
     revalidatePath('/orders/checkout');
     return response;
   } catch (error) {
@@ -74,7 +74,7 @@ export async function updateAddress(
       `/addresses/${addressId}`,
       data,
     );
-    revalidatePath('/me/address');
+    revalidatePath('/address');
     return response;
   } catch (error) {
     rethrowNextError(error);
@@ -89,7 +89,7 @@ export async function updateAddress(
 export async function deleteAddress(addressId: number): Promise<void> {
   try {
     await api.delete(`/addresses/${addressId}`);
-    revalidatePath('/me/address');
+    revalidatePath('/address');
   } catch (error) {
     rethrowNextError(error);
     console.error('배송지 삭제 실패:', error);
@@ -108,7 +108,7 @@ export async function setAsDefaultAddress(
       `/addresses/${addressId}/default`,
       {},
     );
-    revalidatePath('/me/address');
+    revalidatePath('/address');
     return response;
   } catch (error) {
     rethrowNextError(error);

--- a/src/app/actions/address.ts
+++ b/src/app/actions/address.ts
@@ -1,0 +1,144 @@
+'use server';
+
+import { api } from '@/lib/api-client';
+import { revalidatePath } from 'next/cache';
+import { rethrowNextError } from '@/lib/server-action-utils';
+import {
+  ApiStatusResponse,
+  AddressItem,
+  AddressRequest,
+  AddressResponseData,
+  ChangeOrderAddressRequest,
+} from '@/types/domain/address';
+
+/** * 내 배송지 목록 조회 */
+export async function getAddresses(): Promise<AddressItem[]> {
+  try {
+    const response = await api.get<AddressItem[]>('/addresses');
+    return response;
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('배송지 목록 조회 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '배송지 목록 조회에 실패했습니다.',
+    );
+  }
+}
+
+/** * 현재 사용자의 기본 배송지/상세 조회 */
+export async function getMyAddress(): Promise<AddressResponseData> {
+  try {
+    const response = await api.get<AddressResponseData>('/addresses/me');
+    return response;
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('내 배송지 조회 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '배송지 정보를 불러오는데 실패했습니다.',
+    );
+  }
+}
+
+/** * 배송지 등록 */
+export async function registerAddress(
+  data: AddressRequest,
+): Promise<AddressResponseData> {
+  try {
+    const response = await api.post<AddressResponseData, AddressRequest>(
+      '/addresses',
+      data,
+    );
+    revalidatePath('/me/address');
+    revalidatePath('/orders/checkout');
+    return response;
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('배송지 등록 실패:', error);
+    throw new Error(
+      error instanceof Error ? error.message : '배송지 등록에 실패했습니다.',
+    );
+  }
+}
+
+/** * 배송지 수정 */
+export async function updateAddress(
+  addressId: number,
+  data: AddressRequest,
+): Promise<AddressResponseData> {
+  try {
+    const response = await api.patch<AddressResponseData, AddressRequest>(
+      `/addresses/${addressId}`,
+      data,
+    );
+    revalidatePath('/me/address');
+    return response;
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('배송지 수정 실패:', error);
+    throw new Error(
+      error instanceof Error ? error.message : '배송지 수정에 실패했습니다.',
+    );
+  }
+}
+
+/** * 배송지 삭제 */
+export async function deleteAddress(addressId: number): Promise<void> {
+  try {
+    await api.delete(`/addresses/${addressId}`);
+    revalidatePath('/me/address');
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('배송지 삭제 실패:', error);
+    throw new Error(
+      error instanceof Error ? error.message : '배송지 삭제에 실패했습니다.',
+    );
+  }
+}
+
+/** * 기본 배송지 설정 */
+export async function setAsDefaultAddress(
+  addressId: number,
+): Promise<ApiStatusResponse> {
+  try {
+    const response = await api.patch<ApiStatusResponse, Record<string, never>>(
+      `/addresses/${addressId}/default`,
+      {},
+    );
+    revalidatePath('/me/address');
+    return response;
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('기본 배송지 설정 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '기본 배송지 설정에 실패했습니다.',
+    );
+  }
+}
+
+/** * 주문 배송지 변경 (주문 접수 상태일 때만 가능) */
+export async function changeOrderShippingAddress(
+  orderId: number,
+  addressId: number,
+): Promise<void> {
+  try {
+    await api.patch<void, ChangeOrderAddressRequest>(
+      `/orders/${orderId}/delivery-address`,
+      { addressId },
+    );
+    revalidatePath(`/orders/${orderId}`);
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('주문 배송지 변경 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '주문 배송지 변경에 실패했습니다.',
+    );
+  }
+}

--- a/src/app/actions/body-info.ts
+++ b/src/app/actions/body-info.ts
@@ -132,6 +132,8 @@ export async function updateBodyInfoAction(
     }
     revalidatePath('/product/[id]', 'page');
     revalidatePath('/me', 'page');
+    revalidatePath('/me/edit', 'page');
+    revalidatePath('/me/edit/body-info', 'page');
 
     return { success: true, message: '체형 정보가 저장되었습니다.' };
   } catch (error) {

--- a/src/app/actions/user.ts
+++ b/src/app/actions/user.ts
@@ -1,22 +1,116 @@
 'use server';
 
+import { auth } from '/auth';
 import { api } from '@/lib/api-client';
 import { rethrowNextError } from '@/lib/server-action-utils';
+import type { ApiResponse } from '@/types/common';
 import type { UserInfoResDto } from '@/types/domain/user';
+import { revalidatePath } from 'next/cache';
+
+const BASE_URL = process.env.BACKEND_API_URL;
+
+interface ErrorResponse {
+  message?: string;
+}
+
+function normalizeUserPoints(user: UserInfoResDto): UserInfoResDto {
+  const rawPoints: unknown = user.points;
+  if (typeof rawPoints === 'string') {
+    user.points = Number(rawPoints.replace(/,/g, '')) || 0;
+  }
+  return user;
+}
 
 /** 내 정보 조회 */
 export async function getUserInfo(): Promise<UserInfoResDto> {
   try {
     const user = await api.get<UserInfoResDto>('/users/me');
-    if (typeof user.points === 'string') {
-      user.points = Number((user.points as string).replace(/,/g, '')) || 0;
-    }
-    return user;
+    return normalizeUserPoints(user);
   } catch (error) {
     rethrowNextError(error);
     console.error('유저 정보 조회 실패:', error);
     throw new Error(
       error instanceof Error ? error.message : '유저 정보 조회에 실패했습니다.',
+    );
+  }
+}
+
+/** 프로필 이미지 수정 */
+export async function updateProfileImageAction(
+  imageFile: File,
+): Promise<UserInfoResDto> {
+  try {
+    if (!imageFile || imageFile.size === 0) {
+      throw new Error('업로드할 이미지 파일이 없습니다.');
+    }
+    if (!BASE_URL) {
+      throw new Error('BACKEND_API_URL이 설정되지 않았습니다.');
+    }
+
+    const session = await auth();
+    const accessToken = session?.accessToken as string | undefined;
+
+    const formData = new FormData();
+    formData.append('image', imageFile);
+
+    const response = await fetch(`${BASE_URL}/users/me/profile-image`, {
+      method: 'PATCH',
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : {},
+      body: formData,
+      cache: 'no-store',
+    });
+
+    let responseData: unknown = null;
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('application/json')) {
+      responseData = await response.json();
+    } else {
+      responseData = await response.text();
+    }
+
+    if (!response.ok) {
+      const errorData =
+        typeof responseData === 'object' && responseData !== null
+          ? (responseData as ErrorResponse)
+          : { message: String(responseData) };
+      throw new Error(
+        errorData.message || '프로필 이미지 수정에 실패했습니다.',
+      );
+    }
+
+    const user = (responseData as ApiResponse<UserInfoResDto>).data;
+
+    revalidatePath('/me');
+    revalidatePath('/me/edit');
+
+    return normalizeUserPoints(user);
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('프로필 이미지 수정 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '프로필 이미지 수정에 실패했습니다.',
+    );
+  }
+}
+
+/** 프로필 이미지 삭제 */
+export async function deleteProfileImageAction(): Promise<UserInfoResDto> {
+  try {
+    const user = await api.delete<UserInfoResDto>('/users/me/profile-image');
+
+    revalidatePath('/me');
+    revalidatePath('/me/edit');
+
+    return normalizeUserPoints(user);
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('프로필 이미지 삭제 실패:', error);
+    throw new Error(
+      error instanceof Error
+        ? error.message
+        : '프로필 이미지 삭제에 실패했습니다.',
     );
   }
 }

--- a/src/app/address/[addressId]/page.tsx
+++ b/src/app/address/[addressId]/page.tsx
@@ -1,0 +1,34 @@
+import { notFound } from 'next/navigation';
+import { getAddresses } from '@/app/actions/address';
+import AddressForm from '@/components/address/address-form';
+import { CloseXButton } from '@/components/ui/close-button';
+
+interface PageProps {
+  params: Promise<{ addressId: string }>;
+}
+
+export default async function AddressEditPage({ params }: PageProps) {
+  const { addressId } = await params;
+  const id = Number(addressId);
+
+  if (isNaN(id)) notFound();
+
+  const addresses = await getAddresses();
+  const targetAddress = addresses.find((addr) => addr.addressId === id);
+
+  if (!targetAddress) notFound();
+
+  return (
+    <main className="mx-auto min-h-screen max-w-2xl bg-white leading-normal">
+      <header className="relative flex items-center justify-center border-b py-4">
+        <h1 className="text-lg font-bold">배송지 수정</h1>
+        <div className="absolute right-5">
+          <CloseXButton />
+        </div>
+      </header>
+
+      {/* 데이터를 넘겨줌 -> 수정 모드 */}
+      <AddressForm initialData={targetAddress} />
+    </main>
+  );
+}

--- a/src/app/address/[addressId]/page.tsx
+++ b/src/app/address/[addressId]/page.tsx
@@ -11,7 +11,7 @@ export default async function AddressEditPage({ params }: PageProps) {
   const { addressId } = await params;
   const id = Number(addressId);
 
-  if (isNaN(id)) notFound();
+  if (Number.isNaN(id)) notFound();
 
   const addresses = await getAddresses();
   const targetAddress = addresses.find((addr) => addr.addressId === id);
@@ -27,7 +27,6 @@ export default async function AddressEditPage({ params }: PageProps) {
         </div>
       </header>
 
-      {/* 데이터를 넘겨줌 -> 수정 모드 */}
       <AddressForm initialData={targetAddress} />
     </main>
   );

--- a/src/app/address/new/page.tsx
+++ b/src/app/address/new/page.tsx
@@ -1,0 +1,18 @@
+import AddressForm from '@/components/address/address-form';
+import { CloseXButton } from '@/components/ui/close-button';
+
+export default function NewAddressPage() {
+  return (
+    <main className="mx-auto min-h-screen max-w-2xl bg-white leading-normal">
+      <header className="relative flex items-center justify-center border-b py-4">
+        <h1 className="text-lg font-bold">배송지 추가</h1>
+        <div className="absolute right-5">
+          <CloseXButton />
+        </div>
+      </header>
+
+      {/* 데이터 없이 호출 -> 등록 모드 */}
+      <AddressForm />
+    </main>
+  );
+}

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { getAddresses } from '@/app/actions/address';
+import AddressItem from '@/components/address/address-item';
+import { CloseXButton } from '@/components/ui/close-button';
+
+export default async function AddressListPage() {
+  const addresses = await getAddresses();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-white leading-normal">
+      {/* 헤더 */}
+      <header className="sticky top-0 z-10 flex items-center justify-center border-b bg-white py-4">
+        <h1 className="text-lg font-bold">배송지 관리</h1>
+        <div className="absolute right-5">
+          <CloseXButton />
+        </div>
+      </header>
+
+      {/* 목록 영역 */}
+      <div className="flex-1 p-5 pb-24">
+        {addresses.length === 0 ? (
+          <div className="flex h-60 flex-col items-center justify-center text-gray-500">
+            <p>등록된 배송지가 없습니다.</p>
+            <p className="mt-1 text-sm">새로운 배송지를 추가해 주세요.</p>
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {addresses.map((addr) => (
+              <AddressItem key={addr.addressId} item={addr} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* 하단 고정 버튼 */}
+      <div className="fixed bottom-0 mx-auto w-full max-w-2xl bg-white p-5 shadow-[0_-4px_10px_rgba(0,0,0,0.05)]">
+        <Link
+          href="/address/new"
+          className="bg-ongil-teal flex w-full items-center justify-center rounded-xl py-4 text-xl font-bold text-white transition-opacity hover:opacity-90"
+        >
+          + 새 배송지 추가
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -1,28 +1,28 @@
 import Link from 'next/link';
 import { getAddresses } from '@/app/actions/address';
 import AddressItem from '@/components/address/address-item';
-import { CloseXButton } from '@/components/ui/close-button';
+import { CloseButton } from '@/components/ui/close-button';
 
 export default async function AddressListPage() {
   const addresses = await getAddresses();
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-white leading-normal">
-      <header className="sticky top-0 z-10 flex items-center justify-center border-b bg-white py-4">
-        <h1 className="text-lg font-bold">배송지 관리</h1>
-        <div className="absolute right-5">
-          <CloseXButton />
+      <header className="sticky top-0 z-10 flex items-center justify-center border-b border-gray-500 bg-white py-4">
+        <h1 className="text-2xl font-bold">배송지 관리</h1>
+        <div className="absolute top-1/2 left-5 -translate-y-1/2">
+          <CloseButton />
         </div>
       </header>
 
-      <div className="flex-1 p-5 pb-24">
+      <div className="flex-1 px-5 py-6 pb-32">
         {addresses.length === 0 ? (
-          <div className="flex h-60 flex-col items-center justify-center text-gray-500">
-            <p>등록된 배송지가 없습니다.</p>
-            <p className="mt-1 text-sm">새로운 배송지를 추가해 주세요.</p>
+          <div className="flex h-60 flex-col items-center justify-center rounded-3xl border border-[#bdbdbd] bg-white text-gray-500">
+            <p className="text-2xl">등록된 배송지가 없습니다.</p>
+            <p className="mt-1 text-xl">새로운 배송지를 추가해 주세요.</p>
           </div>
         ) : (
-          <div className="flex flex-col">
+          <div className="flex flex-col gap-4">
             {addresses.map((addr) => (
               <AddressItem key={addr.addressId} item={addr} />
             ))}
@@ -30,13 +30,13 @@ export default async function AddressListPage() {
         )}
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 bg-white p-5 shadow-[0_-4px_10px_rgba(0,0,0,0.05)]">
+      <div className="fixed inset-x-0 bottom-0 bg-white p-5">
         <div className="mx-auto w-full max-w-2xl">
           <Link
             href="/address/new"
-            className="bg-ongil-teal flex w-full items-center justify-center rounded-xl py-4 text-xl font-bold text-white transition-opacity hover:opacity-90"
+            className="bg-ongil-teal mx-auto flex h-16 items-center justify-center rounded-3xl text-xl font-bold text-white transition-opacity hover:opacity-90"
           >
-            새 배송지 추가
+            배송지 추가
           </Link>
         </div>
       </div>

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -27,7 +27,9 @@ export default async function AddressListPage({
       return {
         ...address,
         deliveryRequest:
-          myAddress.shippingDetail.deliveryRequest || address.deliveryRequest,
+          myAddress.shippingDetail.deliveryRequest ||
+          address.deliveryRequest ||
+          '',
       };
     }
     return address;

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -1,45 +1,62 @@
-import Link from 'next/link';
-import { getAddresses } from '@/app/actions/address';
-import AddressItem from '@/components/address/address-item';
+import { getAddresses, getMyAddress } from '@/app/actions/address';
+import AddressList from '@/components/address/address-list';
+import AddressPageFooter from '@/components/address/address-page-footer';
 import { CloseButton } from '@/components/ui/close-button';
 
-export default async function AddressListPage() {
-  const addresses = await getAddresses();
+interface AddressListPageProps {
+  searchParams: Promise<{ mode?: string }>;
+}
+
+export default async function AddressListPage({
+  searchParams,
+}: AddressListPageProps) {
+  const params = await searchParams;
+  const isManageMode = params.mode === 'manage';
+
+  const [addresses, myAddress] = await Promise.all([
+    getAddresses(),
+    getMyAddress().catch(() => null),
+  ]);
+
+  const resolvedAddresses = addresses.map((address) => {
+    if (
+      address.isDefault &&
+      myAddress?.hasShippingInfo &&
+      myAddress.shippingDetail.addressId === address.addressId
+    ) {
+      return {
+        ...address,
+        deliveryRequest:
+          myAddress.shippingDetail.deliveryRequest || address.deliveryRequest,
+      };
+    }
+    return address;
+  });
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-white leading-normal">
       <header className="sticky top-0 z-10 flex items-center justify-center border-b border-gray-500 bg-white py-4">
         <h1 className="text-2xl font-bold">배송지 관리</h1>
         <div className="absolute top-1/2 left-5 -translate-y-1/2">
-          <CloseButton />
+          <CloseButton href={isManageMode ? '/me/edit' : undefined} />
         </div>
       </header>
 
       <div className="flex-1 px-5 py-6 pb-32">
-        {addresses.length === 0 ? (
+        {resolvedAddresses.length === 0 ? (
           <div className="flex h-60 flex-col items-center justify-center rounded-3xl border border-[#bdbdbd] bg-white text-gray-500">
             <p className="text-2xl">등록된 배송지가 없습니다.</p>
             <p className="mt-1 text-xl">새로운 배송지를 추가해 주세요.</p>
           </div>
         ) : (
-          <div className="flex flex-col gap-4">
-            {addresses.map((addr) => (
-              <AddressItem key={addr.addressId} item={addr} />
-            ))}
-          </div>
+          <AddressList
+            addresses={resolvedAddresses}
+            showSelectButton={!isManageMode}
+          />
         )}
       </div>
 
-      <div className="fixed inset-x-0 bottom-0 bg-white p-5">
-        <div className="mx-auto w-full max-w-2xl">
-          <Link
-            href="/address/new"
-            className="bg-ongil-teal mx-auto flex h-16 items-center justify-center rounded-3xl text-xl font-bold text-white transition-opacity hover:opacity-90"
-          >
-            배송지 추가
-          </Link>
-        </div>
-      </div>
+      <AddressPageFooter isManageMode={isManageMode} />
     </main>
   );
 }

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -4,7 +4,11 @@ import AddressPageFooter from '@/components/address/address-page-footer';
 import { CloseButton } from '@/components/ui/close-button';
 
 interface AddressListPageProps {
-  searchParams: Promise<{ mode?: string }>;
+  searchParams: Promise<{
+    mode?: string;
+    returnTo?: string;
+    selectedAddressId?: string;
+  }>;
 }
 
 export default async function AddressListPage({
@@ -12,6 +16,19 @@ export default async function AddressListPage({
 }: AddressListPageProps) {
   const params = await searchParams;
   const isManageMode = params.mode === 'manage';
+  const isSelectMode = params.mode === 'select';
+  const selectedAddressId = params.selectedAddressId
+    ? Number(params.selectedAddressId)
+    : null;
+  const initialSelectedAddressId =
+    selectedAddressId && !Number.isNaN(selectedAddressId)
+      ? selectedAddressId
+      : null;
+  const closeHref = isManageMode
+    ? '/me/edit'
+    : isSelectMode
+      ? params.returnTo
+      : undefined;
 
   const [addresses, myAddress] = await Promise.all([
     getAddresses(),
@@ -40,7 +57,7 @@ export default async function AddressListPage({
       <header className="sticky top-0 z-10 flex items-center justify-center border-b border-gray-500 bg-white py-4">
         <h1 className="text-2xl font-bold">배송지 관리</h1>
         <div className="absolute top-1/2 left-5 -translate-y-1/2">
-          <CloseButton href={isManageMode ? '/me/edit' : undefined} />
+          <CloseButton href={closeHref} replace={isSelectMode} />
         </div>
       </header>
 
@@ -54,11 +71,16 @@ export default async function AddressListPage({
           <AddressList
             addresses={resolvedAddresses}
             showSelectButton={!isManageMode}
+            initialSelectedAddressId={initialSelectedAddressId}
           />
         )}
       </div>
 
-      <AddressPageFooter isManageMode={isManageMode} />
+      <AddressPageFooter
+        isManageMode={isManageMode}
+        isSelectMode={isSelectMode}
+        returnTo={params.returnTo}
+      />
     </main>
   );
 }

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -8,7 +8,6 @@ export default async function AddressListPage() {
 
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col bg-white leading-normal">
-      {/* 헤더 */}
       <header className="sticky top-0 z-10 flex items-center justify-center border-b bg-white py-4">
         <h1 className="text-lg font-bold">배송지 관리</h1>
         <div className="absolute right-5">
@@ -16,7 +15,6 @@ export default async function AddressListPage() {
         </div>
       </header>
 
-      {/* 목록 영역 */}
       <div className="flex-1 p-5 pb-24">
         {addresses.length === 0 ? (
           <div className="flex h-60 flex-col items-center justify-center text-gray-500">
@@ -32,14 +30,15 @@ export default async function AddressListPage() {
         )}
       </div>
 
-      {/* 하단 고정 버튼 */}
-      <div className="fixed bottom-0 mx-auto w-full max-w-2xl bg-white p-5 shadow-[0_-4px_10px_rgba(0,0,0,0.05)]">
-        <Link
-          href="/address/new"
-          className="bg-ongil-teal flex w-full items-center justify-center rounded-xl py-4 text-xl font-bold text-white transition-opacity hover:opacity-90"
-        >
-          + 새 배송지 추가
-        </Link>
+      <div className="fixed inset-x-0 bottom-0 bg-white p-5 shadow-[0_-4px_10px_rgba(0,0,0,0.05)]">
+        <div className="mx-auto w-full max-w-2xl">
+          <Link
+            href="/address/new"
+            className="bg-ongil-teal flex w-full items-center justify-center rounded-xl py-4 text-xl font-bold text-white transition-opacity hover:opacity-90"
+          >
+            새 배송지 추가
+          </Link>
+        </div>
       </div>
     </main>
   );

--- a/src/app/body-info/page.tsx
+++ b/src/app/body-info/page.tsx
@@ -1,5 +1,5 @@
 import { getMyBodyInfoAction } from '@/app/actions/body-info';
-import { BodyInfoForm } from '@/components/product/size/body-info-form';
+import BodyInfoForm from '@/components/product/size/body-info-form';
 import { CloseButton } from '../../components/ui/close-button';
 
 // 내 신체 정보 수정 페이지(마이페이지용)

--- a/src/app/body-info/page.tsx
+++ b/src/app/body-info/page.tsx
@@ -10,18 +10,16 @@ export default async function BodyInfoPage() {
     result.success && result.data?.hasBodyInfo ? result.data : null;
 
   return (
-    <div className="flex h-full items-center justify-center bg-gray-50">
-      <div className="flex h-screen w-full max-w-md flex-col overflow-hidden bg-white shadow-lg sm:h-200 sm:rounded-2xl">
-        <div className="flex h-16 items-center gap-6 px-5">
-          <CloseButton />
-          <h1 className="flex-1 pr-10 text-center text-2xl font-semibold">
-            내 체형 정보 수정
-          </h1>
-        </div>
-        <div className="flex-1 overflow-hidden pt-8">
-          <BodyInfoForm initialData={userInfo} />
-        </div>
+    <main className="mx-auto flex min-h-screen max-w-2xl flex-col overscroll-none bg-white">
+      <header className="flex h-16 shrink-0 items-center gap-6 border-b border-[#d9d9d9] px-5">
+        <CloseButton />
+        <h1 className="flex-1 pr-10 text-center text-2xl font-semibold">
+          내 체형 정보 수정
+        </h1>
+      </header>
+      <div className="min-h-0 flex-1 overflow-hidden pt-8">
+        <BodyInfoForm initialData={userInfo} />
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/app/me/edit/body-info/_components/wrapper.tsx
+++ b/src/app/me/edit/body-info/_components/wrapper.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { BodyInfoForm } from '@/components/product/size/body-info-form';
+import BodyInfoForm from '@/components/product/size/body-info-form';
 import { UserBodyInfo } from '@/types/domain/size';
 
 export function MyEditBodyInfoFormWrapper({

--- a/src/app/me/edit/body-info/_components/wrapper.tsx
+++ b/src/app/me/edit/body-info/_components/wrapper.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { BodyInfoForm } from '@/components/product/size/body-info-form';
+import { UserBodyInfo } from '@/types/domain/size';
+
+export function MyEditBodyInfoFormWrapper({
+  userInfo,
+}: {
+  userInfo: UserBodyInfo | null;
+}) {
+  const router = useRouter();
+
+  return (
+    <BodyInfoForm
+      initialData={userInfo}
+      onSuccess={() => {
+        router.replace('/me/edit');
+      }}
+    />
+  );
+}

--- a/src/app/me/edit/body-info/page.tsx
+++ b/src/app/me/edit/body-info/page.tsx
@@ -8,8 +8,8 @@ export default async function MyEditBodyInfoPage() {
     result.success && result.data?.hasBodyInfo ? result.data : null;
 
   return (
-    <div className="flex min-h-[100dvh] items-center justify-center bg-gray-50">
-      <div className="flex h-[100dvh] w-full max-w-md flex-col overflow-hidden bg-white shadow-lg sm:h-200 sm:rounded-2xl">
+    <div className="flex min-h-[100dvh] items-center justify-center overscroll-none bg-gray-50">
+      <div className="flex h-[100dvh] w-full max-w-md flex-col overflow-hidden bg-white shadow-lg sm:rounded-2xl">
         <div className="flex h-16 shrink-0 items-center gap-6 px-5">
           <CloseButton href="/me/edit" />
           <h1 className="flex-1 pr-10 text-center text-2xl font-semibold">

--- a/src/app/me/edit/body-info/page.tsx
+++ b/src/app/me/edit/body-info/page.tsx
@@ -1,0 +1,25 @@
+import { getMyBodyInfoAction } from '@/app/actions/body-info';
+import { CloseButton } from '@/components/ui/close-button';
+import { MyEditBodyInfoFormWrapper } from './_components/wrapper';
+
+export default async function MyEditBodyInfoPage() {
+  const result = await getMyBodyInfoAction();
+  const userInfo =
+    result.success && result.data?.hasBodyInfo ? result.data : null;
+
+  return (
+    <div className="flex min-h-[100dvh] items-center justify-center bg-gray-50">
+      <div className="flex h-[100dvh] w-full max-w-md flex-col overflow-hidden bg-white shadow-lg sm:h-200 sm:rounded-2xl">
+        <div className="flex h-16 shrink-0 items-center gap-6 px-5">
+          <CloseButton href="/me/edit" />
+          <h1 className="flex-1 pr-10 text-center text-2xl font-semibold">
+            내 체형 정보 수정
+          </h1>
+        </div>
+        <div className="min-h-0 flex-1 overflow-hidden pt-8">
+          <MyEditBodyInfoFormWrapper userInfo={userInfo} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/me/edit/page.tsx
+++ b/src/app/me/edit/page.tsx
@@ -46,11 +46,11 @@ export default async function MyEditPage() {
           <div className="rounded-xl border border-[#cfcfcf] bg-white p-4">
             {bodyInfo ? (
               <div className="mb-5 flex flex-col gap-4 text-3xl leading-normal text-black">
-                <p>키: {bodyInfo.height}</p>
-                <p>몸무게: {bodyInfo.weight}</p>
-                <p>상의: {bodyInfo.usualTopSize}</p>
-                <p>하의: {bodyInfo.usualBottomSize}</p>
-                <p>신발 사이즈: {bodyInfo.usualShoeSize}</p>
+                <p>키: {bodyInfo.height ? `${bodyInfo.height}cm` : '-'}</p>
+                <p>몸무게: {bodyInfo.weight ? `${bodyInfo.weight}kg` : '-'}</p>
+                <p>상의: {bodyInfo.usualTopSize || '-'}</p>
+                <p>하의: {bodyInfo.usualBottomSize || '-'}</p>
+                <p>신발 사이즈: {bodyInfo.usualShoeSize || '-'}</p>
               </div>
             ) : (
               <div className="mb-5 flex min-h-[180px] items-center justify-center">

--- a/src/app/me/edit/page.tsx
+++ b/src/app/me/edit/page.tsx
@@ -1,0 +1,74 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { auth } from '/auth';
+import ShippingInfoCardFetcher from '@/components/address/shipping-info-card-fetcher';
+import EditProfilePhotoSheet from '@/components/mypage/edit-profile-photo-sheet';
+import { CloseButton } from '@/components/ui/close-button';
+import { getMyBodyInfoAction } from '@/app/actions/body-info';
+
+export default async function MyEditPage() {
+  const session = await auth();
+
+  if (!session) {
+    redirect('/login');
+  }
+
+  const bodyInfoResult = await getMyBodyInfoAction();
+  const bodyInfo =
+    bodyInfoResult.success && bodyInfoResult.data?.hasBodyInfo
+      ? bodyInfoResult.data
+      : null;
+
+  const userName = session.user.nickName || '사용자';
+
+  return (
+    <main className="mx-auto min-h-screen max-w-2xl bg-white">
+      <header className="sticky top-0 z-10 flex items-center justify-center border-b border-[#d9d9d9] bg-white py-4">
+        <h1 className="text-3xl font-semibold">내 정보 관리</h1>
+        <div className="absolute top-1/2 left-5 -translate-y-1/2">
+          <CloseButton href="/me" />
+        </div>
+      </header>
+
+      <div className="space-y-7 px-5 py-7 pb-20">
+        <EditProfilePhotoSheet
+          imageUrl={session.user.profileUrl}
+          userName={`${userName}님`}
+        />
+
+        <ShippingInfoCardFetcher
+          actionHref="/address?mode=manage"
+          actionLabel="배송지 수정하기"
+        />
+
+        <section>
+          <h2 className="mb-3 text-2xl">내 체형 정보</h2>
+          <div className="rounded-xl border border-[#cfcfcf] bg-white p-4">
+            {bodyInfo ? (
+              <div className="mb-5 flex flex-col gap-4 text-3xl leading-normal text-black">
+                <p>키: {bodyInfo.height}</p>
+                <p>몸무게: {bodyInfo.weight}</p>
+                <p>상의: {bodyInfo.usualTopSize}</p>
+                <p>하의: {bodyInfo.usualBottomSize}</p>
+                <p>신발 사이즈: {bodyInfo.usualShoeSize}</p>
+              </div>
+            ) : (
+              <div className="mb-5 flex min-h-[180px] items-center justify-center">
+                <p className="text-2xl text-[#9a9a9a]">
+                  등록된 체형 정보가 없습니다
+                </p>
+              </div>
+            )}
+
+            <Link
+              href="/me/edit/body-info"
+              className="bg-ongil-teal mx-auto flex h-14 w-[260px] items-center justify-center rounded-xl px-5 text-xl font-medium text-white"
+            >
+              내 정보 수정하기
+            </Link>
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
+++ b/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
@@ -9,7 +9,9 @@ import {
   OrderRefundInfoResponse,
   OrderSummary,
 } from '@/types/domain/order';
+import { AddressItem } from '@/types/domain/address';
 import OrderListCard from '@/components/orders/order-list-card';
+import ShippingInfoCard from '@/components/address/shipping-info-card';
 import Image from 'next/image';
 
 const CANCEL_REASONS = [
@@ -30,10 +32,11 @@ const CANCEL_REASONS = [
   },
 ];
 
-type Step = 'reason' | 'confirm' | 'complete';
+type Step = 'reason' | 'address' | 'confirm' | 'complete';
 
 interface CancelFormProps {
   orderDetail: OrderDetail;
+  defaultAddress: AddressItem | null;
 }
 
 function useFocusTrap(active: boolean) {
@@ -73,7 +76,7 @@ function useFocusTrap(active: boolean) {
   return ref;
 }
 
-export function CancelForm({ orderDetail }: CancelFormProps) {
+export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
   const router = useRouter();
   const orderId = orderDetail.id;
 
@@ -355,6 +358,27 @@ export function CancelForm({ orderDetail }: CancelFormProps) {
     );
   }
 
+  // --- 배송지 단계 ---
+  if (step === 'address') {
+    return (
+      <div className="flex h-full flex-col justify-between bg-white">
+        <div className="flex-1 pb-10">
+          <ShippingInfoCard address={defaultAddress} />
+        </div>
+
+        {/* 하단 버튼 영역 */}
+        <div className="border-ongil-teal flex w-full border-t bg-white p-6">
+          <button
+            className="h-14 w-full rounded-xl bg-[#D9D9D9] text-lg font-bold"
+            onClick={() => setStep('reason')}
+          >
+            이전 단계
+          </button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <p className="mb-8 text-center text-xl">취소 사유를 선택 해주세요</p>
@@ -393,9 +417,11 @@ export function CancelForm({ orderDetail }: CancelFormProps) {
           selectedReason ? 'bg-ongil-teal' : 'cursor-not-allowed bg-gray-300'
         }`}
         disabled={!selectedReason}
-        onClick={() => setStep('confirm')}
+        onClick={() =>
+          setStep(selectedReason === 'WRONG_ADDRESS' ? 'address' : 'confirm')
+        }
       >
-        주문 취소
+        {selectedReason === 'WRONG_ADDRESS' ? '배송지 수정' : '주문 취소'}
       </button>
     </>
   );

--- a/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
+++ b/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
@@ -358,21 +358,35 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
     );
   }
 
-  // --- 배송지 단계 ---
   if (step === 'address') {
+    const canProceed = !!defaultAddress;
+
     return (
       <div className="flex h-full flex-col justify-between bg-white">
         <div className="flex-1 pb-10">
           <ShippingInfoCard address={defaultAddress} />
+          <p className="mt-4 px-1 text-center text-sm text-gray-600">
+            {canProceed
+              ? '배송지를 수정한 뒤 주문 취소를 계속하려면 다음 단계를 눌러주세요.'
+              : '배송지 정보가 없어 다음 단계로 진행할 수 없습니다. 배송지를 먼저 입력해주세요.'}
+          </p>
         </div>
 
-        {/* 하단 버튼 영역 */}
-        <div className="border-ongil-teal flex w-full border-t bg-white p-6">
+        <div className="border-ongil-teal grid w-full grid-cols-2 gap-4 border-t bg-white p-6">
           <button
             className="h-14 w-full rounded-xl bg-[#D9D9D9] text-lg font-bold"
             onClick={() => setStep('reason')}
           >
             이전 단계
+          </button>
+          <button
+            className={`h-14 w-full rounded-xl text-lg font-bold text-white ${
+              canProceed ? 'bg-ongil-teal' : 'cursor-not-allowed bg-gray-300'
+            }`}
+            onClick={() => setStep('confirm')}
+            disabled={!canProceed}
+          >
+            다음 단계
           </button>
         </div>
       </div>

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import { getOrderDetail } from '@/app/actions/order';
+import { getAddresses } from '@/app/actions/address';
 import { notFound } from 'next/navigation';
 import { CloseXButton } from '@/components/ui/close-button';
 import { CancelForm } from './_components/cancel-form';
@@ -24,6 +25,8 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
     notFound();
   }
   const orderDetail = await getOrderDetail(numericId);
+  const addresses = await getAddresses();
+  const defaultAddress = addresses.find((addr) => addr.isDefault) || null;
 
   return (
     <div className="mx-auto min-h-screen max-w-2xl bg-white px-5 pb-20 leading-normal">
@@ -34,7 +37,7 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
         </div>
       </header>
 
-      <CancelForm orderDetail={orderDetail} />
+      <CancelForm orderDetail={orderDetail} defaultAddress={defaultAddress} />
     </div>
   );
 }

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -19,13 +19,17 @@ interface CancelPageProps {
 export default async function CancelReasonPage({ params }: CancelPageProps) {
   const session = await auth();
   if (!session) redirect('/login');
+
   const { orderId } = await params;
   const numericId = Number(orderId);
   if (Number.isNaN(numericId)) {
     notFound();
   }
-  const orderDetail = await getOrderDetail(numericId);
-  const addresses = await getAddresses();
+
+  const [orderDetail, addresses] = await Promise.all([
+    getOrderDetail(numericId),
+    getAddresses(),
+  ]);
   const defaultAddress = addresses.find((addr) => addr.isDefault) || null;
 
   return (

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -26,10 +26,11 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
     notFound();
   }
 
-  const [orderDetail, addresses] = await Promise.all([
-    getOrderDetail(numericId),
-    getAddresses(),
-  ]);
+  const orderDetail = await getOrderDetail(numericId);
+  const addresses = await getAddresses().catch((error) => {
+    console.error('배송지 목록 조회 실패:', error);
+    return [];
+  });
   const defaultAddress = addresses.find((addr) => addr.isDefault) || null;
 
   return (

--- a/src/app/payment/_components/payment-context.tsx
+++ b/src/app/payment/_components/payment-context.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import type { UserInfoResDto } from '@/types/domain/user';
+import type { AddressItem } from '@/types/domain/address';
 import {
   createOrderFromCart,
   createOrderFromProduct,
@@ -45,6 +46,7 @@ interface ProviderProps {
   user: UserInfoResDto;
   items: PaymentDisplayItem[];
   orderType: 'cart' | 'direct';
+  defaultAddress: AddressItem | null;
   children: ReactNode;
 }
 
@@ -56,6 +58,7 @@ export function PaymentProvider({
   user,
   items,
   orderType,
+  defaultAddress,
   children,
 }: ProviderProps) {
   const router = useRouter();
@@ -63,12 +66,12 @@ export function PaymentProvider({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const [shippingInfo, setShippingInfo] = useState<ShippingFormState>({
-    recipient: user.name,
-    recipientPhone: user.phone || '',
-    deliveryAddress: '',
-    detailAddress: '',
-    postalCode: '',
-    deliveryMessage: '',
+    recipient: defaultAddress?.recipientName || user.name,
+    recipientPhone: defaultAddress?.recipientPhone || user.phone || '',
+    deliveryAddress: defaultAddress?.baseAddress || '',
+    detailAddress: defaultAddress?.detailAddress || '',
+    postalCode: defaultAddress?.postalCode || '',
+    deliveryMessage: defaultAddress?.deliveryRequest || '',
   });
 
   const [usedPoints, setUsedPoints] = useState(0);
@@ -162,10 +165,8 @@ export function ConnectedStepNavigator() {
  * Context와 연결된 배송지 정보 섹션
  */
 export function ConnectedShippingSection() {
-  const { shippingInfo, setShippingInfo } = usePayment();
-  return (
-    <ShippingInfoSection value={shippingInfo} onChange={setShippingInfo} />
-  );
+  const { shippingInfo } = usePayment();
+  return <ShippingInfoSection value={shippingInfo} />;
 }
 
 /**

--- a/src/app/payment/_components/shipping-info.tsx
+++ b/src/app/payment/_components/shipping-info.tsx
@@ -1,6 +1,8 @@
-import { useDaumPostcodePopup } from 'react-daum-postcode';
-import { Input } from '@/components/ui/input';
-import Label from '@/components/ui/label';
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import ShippingInfoCard from '@/components/address/shipping-info-card';
+import type { AddressItem } from '@/types/domain/address';
 
 // 배송지 수정 페이지 구현 되면 다시 컴포넌트 UI 잡기
 
@@ -15,118 +17,46 @@ export interface ShippingFormState {
 
 interface Props {
   value: ShippingFormState;
-  onChange: (value: ShippingFormState) => void;
 }
 
-export default function ShippingInfoSection({ value, onChange }: Props) {
-  const openPostcode = useDaumPostcodePopup();
+export default function ShippingInfoSection({ value }: Props) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
-  const handleChange = (field: keyof ShippingFormState, val: string) => {
-    onChange({ ...value, [field]: val });
-  };
+  const address: AddressItem | null =
+    value.recipient && value.recipientPhone && value.deliveryAddress
+      ? {
+          addressId: 0,
+          recipientName: value.recipient,
+          recipientPhone: value.recipientPhone,
+          baseAddress: value.deliveryAddress,
+          detailAddress: value.detailAddress,
+          postalCode: value.postalCode,
+          isDefault: true,
+          deliveryRequest: value.deliveryMessage,
+        }
+      : null;
 
-  const handlePostcodeComplete = (data: {
-    address: string;
-    addressType: string;
-    bname: string;
-    buildingName: string;
-    zonecode: string;
-  }) => {
-    let fullAddress = data.address;
-    let extraAddress = '';
-
-    if (data.addressType === 'R') {
-      if (data.bname !== '') {
-        extraAddress += data.bname;
-      }
-      if (data.buildingName !== '') {
-        extraAddress +=
-          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
-      }
-      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
-    }
-
-    onChange({
-      ...value,
-      postalCode: data.zonecode,
-      deliveryAddress: fullAddress,
-    });
-  };
-
-  const handleSearchPostcode = () => {
-    openPostcode({ onComplete: handlePostcodeComplete });
-  };
+  const currentSearch = searchParams.toString();
+  const currentPath = currentSearch ? `${pathname}?${currentSearch}` : pathname;
+  const params = new URLSearchParams({
+    mode: 'select',
+    returnTo: currentPath,
+  });
+  const selectedAddressId = searchParams.get('selectedAddressId');
+  if (selectedAddressId) {
+    params.set('selectedAddressId', selectedAddressId);
+  }
+  const addressActionHref = `/address?${params.toString()}`;
 
   return (
-    <div className="p-5">
-      <h2 className="mb-4 text-lg font-bold">배송지를 확인 해주세요</h2>
-      <div className="space-y-4">
-        <div className="grid grid-cols-2 gap-3">
-          <div className="space-y-1">
-            <Label htmlFor="recipient" className="text-xs text-gray-500">
-              받는 분
-            </Label>
-            <Input
-              id="recipient"
-              value={value.recipient}
-              onChange={(e) => handleChange('recipient', e.target.value)}
-              placeholder="이름"
-            />
-          </div>
-          <div className="space-y-1">
-            <Label htmlFor="phone" className="text-xs text-gray-500">
-              연락처
-            </Label>
-            <Input
-              id="phone"
-              value={value.recipientPhone}
-              onChange={(e) => handleChange('recipientPhone', e.target.value)}
-              placeholder="010-0000-0000"
-            />
-          </div>
-        </div>
-
-        <div className="space-y-2">
-          <div className="flex gap-2">
-            <Input
-              value={value.postalCode}
-              readOnly
-              placeholder="우편번호"
-              className="w-1/3 bg-gray-50"
-            />
-            <button
-              type="button"
-              onClick={handleSearchPostcode}
-              className="rounded-md bg-black px-3 py-2 text-xs text-white"
-            >
-              우편번호 찾기
-            </button>
-          </div>
-          <Input
-            value={value.deliveryAddress}
-            readOnly
-            placeholder="기본 주소"
-            className="bg-gray-50"
-          />
-          <Input
-            value={value.detailAddress}
-            onChange={(e) => handleChange('detailAddress', e.target.value)}
-            placeholder="상세 주소 입력"
-          />
-        </div>
-
-        <div className="space-y-1">
-          <Label htmlFor="msg" className="text-xs text-gray-500">
-            배송 요청사항
-          </Label>
-          <Input
-            id="msg"
-            value={value.deliveryMessage}
-            onChange={(e) => handleChange('deliveryMessage', e.target.value)}
-            placeholder="예: 문 앞에 놓아주세요."
-          />
-        </div>
-      </div>
+    <div className="px-5">
+      <ShippingInfoCard
+        address={address}
+        title="배송지를 확인 해주세요"
+        actionHref={addressActionHref}
+        actionLabel="배송지 수정하기"
+      />
     </div>
   );
 }

--- a/src/app/payment/_components/step-navigator.tsx
+++ b/src/app/payment/_components/step-navigator.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import { CloseButton } from '@/components/ui/close-button';
 import { cn } from '@/lib/utils';
 import { SECTIONS } from './constants';
@@ -10,11 +11,21 @@ interface Props {
 }
 
 export default function StepNavigator({ activeStep, onStepChange }: Props) {
+  const searchParams = useSearchParams();
+
   const steps = [
     { id: SECTIONS.ITEMS, label: '주문정보\n확인' },
     { id: SECTIONS.SHIPPING, label: '배송지\n확인' },
     { id: SECTIONS.PAYMENT, label: '적립금/캐시\n 확인' },
   ];
+
+  const productId = searchParams.get('productId');
+  const backHref =
+    searchParams.get('cart') === 'true'
+      ? '/cart'
+      : productId
+        ? `/product/${productId}`
+        : undefined;
 
   // 현재 활성 단계 계산 (activeStep이 비어있으면 첫 번째 단계로 간주)
   const currentId = activeStep || steps[0].id;
@@ -32,7 +43,7 @@ export default function StepNavigator({ activeStep, onStepChange }: Props) {
       <header className="fixed top-0 z-50 w-full max-w-md bg-white backdrop-blur-md">
         {/* 1. 타이틀 바 */}
         <div className="mt-8 flex h-14 items-center gap-4 px-6">
-          <CloseButton />
+          <CloseButton href={backHref} />
           <h1 className="flex-1 pr-8 text-center text-3xl leading-normal font-semibold">
             주문/결제
           </h1>

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useDaumPostcodePopup } from 'react-daum-postcode';
+import {
+  registerAddress,
+  setAsDefaultAddress,
+  updateAddress,
+} from '@/app/actions/address';
+import { AddressItem, AddressRequest } from '@/types/domain/address';
+import { Input } from '@/components/ui/input';
+import Label from '@/components/ui/label';
+
+interface AddressFormProps {
+  initialData?: AddressItem;
+}
+
+interface PostcodeData {
+  address: string;
+  addressType: string;
+  bname: string;
+  buildingName: string;
+  zonecode: string;
+}
+
+export default function AddressForm({ initialData }: AddressFormProps) {
+  const router = useRouter();
+  const openPostcode = useDaumPostcodePopup();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDefaultAddress, setIsDefaultAddress] = useState(
+    initialData?.isDefault ?? false,
+  );
+
+  const isEditMode = !!initialData;
+
+  const [formState, setFormState] = useState<AddressRequest>({
+    recipientName: initialData?.recipientName || '',
+    phone: initialData?.recipientPhone || '',
+    postalCode: initialData?.postalCode || '',
+    baseAddress: initialData?.baseAddress || '',
+    detailAddress: initialData?.detailAddress || '',
+    deliveryRequest: '',
+  });
+
+  const handleChange = (field: keyof AddressRequest, val: string) => {
+    setFormState((prev) => ({ ...prev, [field]: val }));
+  };
+
+  const handlePostcodeComplete = (data: PostcodeData) => {
+    let fullAddress = data.address;
+    let extraAddress = '';
+
+    if (data.addressType === 'R') {
+      if (data.bname !== '') extraAddress += data.bname;
+      if (data.buildingName !== '') {
+        extraAddress +=
+          extraAddress !== '' ? `, ${data.buildingName}` : data.buildingName;
+      }
+      fullAddress += extraAddress !== '' ? ` (${extraAddress})` : '';
+    }
+
+    setFormState((prev) => ({
+      ...prev,
+      postalCode: data.zonecode,
+      baseAddress: fullAddress,
+    }));
+  };
+
+  const handleSearchPostcode = () => {
+    openPostcode({ onComplete: handlePostcodeComplete });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (
+      !formState.recipientName ||
+      !formState.phone ||
+      !formState.postalCode ||
+      !formState.baseAddress ||
+      !formState.detailAddress
+    ) {
+      alert('필수 정보를 모두 입력해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      let targetAddressId: number | null = null;
+
+      if (isEditMode && initialData) {
+        await updateAddress(initialData.addressId, formState);
+        targetAddressId = initialData.addressId;
+      } else {
+        const response = await registerAddress(formState);
+        targetAddressId = response.shippingDetail.addressId;
+      }
+
+      if (isDefaultAddress && targetAddressId) {
+        await setAsDefaultAddress(targetAddressId);
+      }
+
+      alert(
+        isEditMode ? '배송지가 수정되었습니다.' : '배송지가 등록되었습니다.',
+      );
+      router.back();
+      router.refresh();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '작업에 실패했습니다.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex min-h-[calc(100vh-72px)] flex-col bg-white px-6 pt-7 pb-8"
+    >
+      <div className="space-y-8">
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="recipient" className="text-xl font-semibold">
+            수령인
+          </Label>
+          <Input
+            id="recipient"
+            value={formState.recipientName}
+            onChange={(e) => handleChange('recipientName', e.target.value)}
+            placeholder="택배를 받을 분의 이름을 입력해주세요"
+            className="h-16 rounded-2xl border-[#c8bebe] px-4 text-xl placeholder:text-base placeholder:text-[#b1a8a8] focus-visible:ring-0"
+          />
+        </div>
+
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="phone" className="text-xl font-semibold">
+            휴대폰
+          </Label>
+          <Input
+            id="phone"
+            value={formState.phone}
+            onChange={(e) => handleChange('phone', e.target.value)}
+            placeholder="휴대폰 번호를 입력해주세요"
+            className="h-16 rounded-2xl border-[#c8bebe] px-4 text-xl placeholder:text-base placeholder:text-[#b1a8a8] focus-visible:ring-0"
+          />
+        </div>
+
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="postalCode" className="text-xl font-semibold">
+            우편번호
+          </Label>
+          <div className="flex gap-4">
+            <Input
+              id="postalCode"
+              value={formState.postalCode}
+              readOnly
+              placeholder="우편번호를 검색해주세요"
+              className="h-16 w-1/2 rounded-2xl border-[#c8bebe] bg-[#fafafa] px-4 text-xl placeholder:text-[#b1a8a8] focus-visible:ring-0"
+            />
+            <button
+              type="button"
+              onClick={handleSearchPostcode}
+              className="h-16 rounded-2xl border border-[#c8bebe] px-6 text-lg font-medium text-[#1d1b1b]"
+            >
+              주소찾기
+            </button>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="baseAddress" className="text-xl font-semibold">
+            주소
+          </Label>
+          <Input
+            id="baseAddress"
+            value={formState.baseAddress}
+            readOnly
+            placeholder="주소를 검색해주세요"
+            className="h-16 rounded-2xl border-[#c8bebe] bg-[#fafafa] px-4 text-[20px] placeholder:text-[#b1a8a8] focus-visible:ring-0"
+          />
+        </div>
+
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="detailAddress" className="text-xl font-semibold">
+            상세주소
+          </Label>
+          <Input
+            id="detailAddress"
+            value={formState.detailAddress}
+            onChange={(e) => handleChange('detailAddress', e.target.value)}
+            placeholder="상세 주소를 입력해주세요"
+            className="h-16 rounded-2xl border-[#c8bebe] px-4 text-xl placeholder:text-[#b1a8a8] focus-visible:ring-0"
+          />
+        </div>
+
+        <div className="items-center gap-4">
+          <span aria-hidden="true" />
+          <div className="relative">
+            <Input
+              id="deliveryRequest"
+              value={formState.deliveryRequest || ''}
+              onChange={(e) => handleChange('deliveryRequest', e.target.value)}
+              placeholder="배송 요청사항을 입력해주세요"
+              className="h-16 rounded-2xl border-[#c8bebe] pr-12 pl-4 text-xl placeholder:text-[#b1a8a8] focus-visible:ring-0"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center justify-start gap-4 pt-2">
+          <span aria-hidden="true" />
+          <label
+            htmlFor="isDefaultAddress"
+            className="flex items-center gap-3 text-xl font-medium text-[#1d1b1b]"
+          >
+            <input
+              id="isDefaultAddress"
+              type="checkbox"
+              checked={isDefaultAddress}
+              onChange={(e) => setIsDefaultAddress(e.target.checked)}
+              className="accent-ongil-teal h-6 w-6 rounded-sm border border-[#9d9494]"
+            />
+            기본 배송지로 선택하기
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-auto flex items-center justify-center px-8 pt-16">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="bg-ongil-teal h-16 w-full rounded-3xl text-3xl font-semibold text-white disabled:bg-gray-300"
+        >
+          {isSubmitting ? '처리 중...' : '저장'}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useDaumPostcodePopup } from 'react-daum-postcode';
+import type { Address as PostcodeData } from 'react-daum-postcode';
 import {
   registerAddress,
   setAsDefaultAddress,
@@ -14,14 +15,6 @@ import Label from '@/components/ui/label';
 
 interface AddressFormProps {
   initialData?: AddressItem;
-}
-
-interface PostcodeData {
-  address: string;
-  addressType: string;
-  bname: string;
-  buildingName: string;
-  zonecode: string;
 }
 
 export default function AddressForm({ initialData }: AddressFormProps) {
@@ -112,7 +105,12 @@ export default function AddressForm({ initialData }: AddressFormProps) {
       }
 
       if (isDefaultAddress && targetAddressId != null) {
-        await setAsDefaultAddress(targetAddressId);
+        try {
+          await setAsDefaultAddress(targetAddressId);
+        } catch (error) {
+          console.error('기본 배송지 설정 실패:', error);
+          alert('주소는 저장되었으나 기본 배송지 설정에 실패했습니다.');
+        }
       }
 
       alert(

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -28,11 +28,14 @@ export default function AddressForm({ initialData }: AddressFormProps) {
   const router = useRouter();
   const openPostcode = useDaumPostcodePopup();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isDeliveryRequestTouched, setIsDeliveryRequestTouched] =
+    useState(false);
   const [isDefaultAddress, setIsDefaultAddress] = useState(
     initialData?.isDefault ?? false,
   );
 
   const isEditMode = !!initialData;
+  const initialDeliveryRequest = initialData?.deliveryRequest?.trim() || '';
 
   const [formState, setFormState] = useState<AddressRequest>({
     recipientName: initialData?.recipientName || '',
@@ -40,7 +43,7 @@ export default function AddressForm({ initialData }: AddressFormProps) {
     postalCode: initialData?.postalCode || '',
     baseAddress: initialData?.baseAddress || '',
     detailAddress: initialData?.detailAddress || '',
-    deliveryRequest: '',
+    deliveryRequest: initialData?.deliveryRequest || '',
   });
 
   const handleChange = (field: keyof AddressRequest, val: string) => {
@@ -90,7 +93,12 @@ export default function AddressForm({ initialData }: AddressFormProps) {
       let targetAddressId: number | null = null;
 
       if (isEditMode && initialData) {
-        await updateAddress(initialData.addressId, formState);
+        const updatePayload: AddressRequest = { ...formState };
+        if (!isDeliveryRequestTouched && !initialDeliveryRequest) {
+          delete updatePayload.deliveryRequest;
+        }
+
+        await updateAddress(initialData.addressId, updatePayload);
         targetAddressId = initialData.addressId;
       } else {
         const response = await registerAddress(formState);
@@ -200,7 +208,10 @@ export default function AddressForm({ initialData }: AddressFormProps) {
             <Input
               id="deliveryRequest"
               value={formState.deliveryRequest || ''}
-              onChange={(e) => handleChange('deliveryRequest', e.target.value)}
+              onChange={(e) => {
+                setIsDeliveryRequestTouched(true);
+                handleChange('deliveryRequest', e.target.value);
+              }}
               placeholder="배송 요청사항을 입력해주세요"
               className="h-16 rounded-2xl border-[#c8bebe] pr-12 pl-4 text-xl placeholder:text-[#b1a8a8] focus-visible:ring-0"
             />

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -36,7 +36,6 @@ export default function AddressForm({ initialData }: AddressFormProps) {
 
   const isEditMode = !!initialData;
   const isDefaultAddressLocked = isEditMode && initialData?.isDefault === true;
-  const initialDeliveryRequest = initialData?.deliveryRequest?.trim() || '';
 
   const [formState, setFormState] = useState<AddressRequest>({
     recipientName: initialData?.recipientName || '',
@@ -101,7 +100,7 @@ export default function AddressForm({ initialData }: AddressFormProps) {
 
       if (isEditMode && initialData) {
         const updatePayload: AddressRequest = { ...formState };
-        if (!isDeliveryRequestTouched && !initialDeliveryRequest) {
+        if (!isDeliveryRequestTouched) {
           delete updatePayload.deliveryRequest;
         }
 

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -1,4 +1,4 @@
-﻿'use client';
+'use client';
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -35,6 +35,7 @@ export default function AddressForm({ initialData }: AddressFormProps) {
   );
 
   const isEditMode = !!initialData;
+  const isDefaultAddressLocked = isEditMode && initialData?.isDefault === true;
   const initialDeliveryRequest = initialData?.deliveryRequest?.trim() || '';
 
   const [formState, setFormState] = useState<AddressRequest>({
@@ -88,6 +89,12 @@ export default function AddressForm({ initialData }: AddressFormProps) {
       return;
     }
 
+    const phoneRegex = /^01[0-9]-?\d{3,4}-?\d{4}$/;
+    if (!phoneRegex.test(formState.phone)) {
+      alert('올바른 휴대폰 번호를 입력해주세요.');
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       let targetAddressId: number | null = null;
@@ -105,7 +112,7 @@ export default function AddressForm({ initialData }: AddressFormProps) {
         targetAddressId = response.shippingDetail.addressId;
       }
 
-      if (isDefaultAddress && targetAddressId) {
+      if (isDefaultAddress && targetAddressId != null) {
         await setAsDefaultAddress(targetAddressId);
       }
 
@@ -147,6 +154,7 @@ export default function AddressForm({ initialData }: AddressFormProps) {
           </Label>
           <Input
             id="phone"
+            type="tel"
             value={formState.phone}
             onChange={(e) => handleChange('phone', e.target.value)}
             placeholder="휴대폰 번호를 입력해주세요"
@@ -202,8 +210,10 @@ export default function AddressForm({ initialData }: AddressFormProps) {
           />
         </div>
 
-        <div className="items-center gap-4">
-          <span aria-hidden="true" />
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4">
+          <Label htmlFor="deliveryRequest" className="text-xl font-semibold">
+            요청사항
+          </Label>
           <div className="relative">
             <Input
               id="deliveryRequest"
@@ -218,21 +228,23 @@ export default function AddressForm({ initialData }: AddressFormProps) {
           </div>
         </div>
 
-        <div className="flex items-center justify-start gap-4 pt-2">
-          <span aria-hidden="true" />
-          <label
-            htmlFor="isDefaultAddress"
-            className="flex items-center gap-3 text-xl font-medium text-[#1d1b1b]"
-          >
-            <input
-              id="isDefaultAddress"
-              type="checkbox"
-              checked={isDefaultAddress}
-              onChange={(e) => setIsDefaultAddress(e.target.checked)}
-              className="accent-ongil-teal h-6 w-6 rounded-sm border border-[#9d9494]"
-            />
-            기본 배송지로 선택하기
-          </label>
+        <div className="grid grid-cols-[88px_1fr] items-center gap-4 pt-2">
+          <div className="col-start-2">
+            <label
+              htmlFor="isDefaultAddress"
+              className="flex items-center gap-3 text-xl font-medium text-[#1d1b1b]"
+            >
+              <input
+                id="isDefaultAddress"
+                type="checkbox"
+                checked={isDefaultAddress}
+                onChange={(e) => setIsDefaultAddress(e.target.checked)}
+                disabled={isDefaultAddressLocked}
+                className="accent-ongil-teal h-6 w-6 rounded-sm border border-[#9d9494]"
+              />
+              기본 배송지로 선택하기
+            </label>
+          </div>
         </div>
       </div>
 

--- a/src/components/address/address-form.tsx
+++ b/src/components/address/address-form.tsx
@@ -1,4 +1,4 @@
-'use client';
+﻿'use client';
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
@@ -102,12 +102,13 @@ export default function AddressForm({ initialData }: AddressFormProps) {
       }
 
       alert(
-        isEditMode ? '배송지가 수정되었습니다.' : '배송지가 등록되었습니다.',
+        isEditMode
+          ? '배송지 정보가 수정되었습니다.'
+          : '배송지 정보가 등록되었습니다.',
       );
       router.back();
-      router.refresh();
     } catch (error) {
-      alert(error instanceof Error ? error.message : '작업에 실패했습니다.');
+      alert(error instanceof Error ? error.message : '오류가 발생했습니다.');
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -24,6 +24,7 @@ export default function AddressItem({ item }: AddressItemProps) {
       router.refresh();
     } catch (error) {
       alert(error instanceof Error ? error.message : '삭제 실패');
+    } finally {
       setIsDeleting(false);
     }
   };

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -58,6 +58,7 @@ export default function AddressItem({ item }: AddressItemProps) {
         <button
           onClick={handleDelete}
           disabled={isDeleting}
+          aria-label={`${item.recipientName} 배송지 삭제`}
           className="text-base text-gray-500 underline underline-offset-4 hover:text-red-500"
         >
           {isDeleting ? '삭제 중...' : '삭제'}
@@ -84,6 +85,7 @@ export default function AddressItem({ item }: AddressItemProps) {
         <button
           onClick={handleSetDefault}
           disabled={item.isDefault || isSettingDefault}
+          aria-label={`${item.recipientName} 배송지를 기본 배송지로 설정`}
           className={`h-16 rounded-2xl text-xl font-semibold ${
             item.isDefault
               ? 'cursor-not-allowed bg-[#cfcfcf] text-[#666]'

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { deleteAddress, setAsDefaultAddress } from '@/app/actions/address';
+import { AddressItem as AddressItemType } from '@/types/domain/address';
+
+interface AddressItemProps {
+  item: AddressItemType;
+}
+
+export default function AddressItem({ item }: AddressItemProps) {
+  const router = useRouter();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isSettingDefault, setIsSettingDefault] = useState(false);
+
+  const handleDelete = async () => {
+    if (!confirm('정말 이 배송지를 삭제하시겠습니까?')) return;
+
+    setIsDeleting(true);
+    try {
+      await deleteAddress(item.addressId);
+      router.refresh();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '삭제 실패');
+      setIsDeleting(false);
+    }
+  };
+
+  const handleSetDefault = async () => {
+    if (item.isDefault) return;
+
+    setIsSettingDefault(true);
+    try {
+      await setAsDefaultAddress(item.addressId);
+      router.refresh();
+    } catch (error) {
+      alert(error instanceof Error ? error.message : '설정 실패');
+    } finally {
+      setIsSettingDefault(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 border-b py-5 last:border-0">
+      <div className="flex items-start justify-between">
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <span className="text-lg font-bold text-gray-900">
+              {item.recipientName}
+            </span>
+            {item.isDefault && (
+              <span className="bg-ongil-teal/10 text-ongil-teal rounded-full px-2 py-0.5 text-xs font-semibold">
+                기본 배송지
+              </span>
+            )}
+          </div>
+          <span className="text-gray-500">{item.recipientPhone}</span>
+          <div className="mt-1 text-gray-800">
+            <span>({item.postalCode}) </span>
+            <span>
+              {item.baseAddress} {item.detailAddress}
+            </span>
+          </div>
+        </div>
+
+        <Link
+          href={`/address/${item.addressId}`}
+          className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-600 hover:bg-gray-50"
+        >
+          수정
+        </Link>
+      </div>
+
+      <div className="flex items-center gap-3">
+        {!item.isDefault && (
+          <button
+            onClick={handleSetDefault}
+            disabled={isSettingDefault}
+            className="text-sm text-gray-500 underline decoration-gray-300 underline-offset-4 hover:text-gray-800"
+          >
+            {isSettingDefault ? '설정 중...' : '기본 배송지로 설정'}
+          </button>
+        )}
+
+        {/* 구분선 */}
+        {!item.isDefault && <span className="h-3 w-px bg-gray-300"></span>}
+
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="text-sm text-gray-500 underline decoration-gray-300 underline-offset-4 hover:text-red-500"
+        >
+          {isDeleting ? '삭제 중...' : '삭제'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -44,56 +44,53 @@ export default function AddressItem({ item }: AddressItemProps) {
   };
 
   return (
-    <div className="flex flex-col gap-3 border-b py-5 last:border-0">
-      <div className="flex items-start justify-between">
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <span className="text-lg font-bold text-gray-900">
-              {item.recipientName}
-            </span>
-            {item.isDefault && (
-              <span className="bg-ongil-teal/10 text-ongil-teal rounded-full px-2 py-0.5 text-xs font-semibold">
-                기본 배송지
-              </span>
-            )}
-          </div>
-          <span className="text-gray-500">{item.recipientPhone}</span>
-          <div className="mt-1 text-gray-800">
-            <span>({item.postalCode}) </span>
-            <span>
-              {item.baseAddress} {item.detailAddress}
-            </span>
-          </div>
-        </div>
-
-        <Link
-          href={`/address/${item.addressId}`}
-          className="rounded-md border border-gray-300 px-3 py-1 text-sm text-gray-600 hover:bg-gray-50"
+    <div className="rounded-3xl border border-[#bdbdbd] bg-white p-4">
+      <div className="mb-5 flex items-center justify-between">
+        <span
+          className={`inline-flex rounded-xl px-5 py-2 text-2xl ${
+            item.isDefault
+              ? 'bg-ongil-teal text-white'
+              : 'bg-white text-gray-600'
+          }`}
         >
-          수정
-        </Link>
-      </div>
-
-      <div className="flex items-center gap-3">
-        {!item.isDefault && (
-          <button
-            onClick={handleSetDefault}
-            disabled={isSettingDefault}
-            className="text-sm text-gray-500 underline decoration-gray-300 underline-offset-4 hover:text-gray-800"
-          >
-            {isSettingDefault ? '설정 중...' : '기본 배송지로 설정'}
-          </button>
-        )}
-
-        {/* 구분선 */}
-        {!item.isDefault && <span className="h-3 w-px bg-gray-300"></span>}
-
+          {item.isDefault ? '기본 배송지' : '일반 배송지'}
+        </span>
         <button
           onClick={handleDelete}
           disabled={isDeleting}
-          className="text-sm text-gray-500 underline decoration-gray-300 underline-offset-4 hover:text-red-500"
+          className="text-base text-gray-500 underline underline-offset-4 hover:text-red-500"
         >
           {isDeleting ? '삭제 중...' : '삭제'}
+        </button>
+      </div>
+
+      <div className="space-y-7 px-2 text-xl">
+        <p>{item.recipientName}</p>
+        <p>{item.baseAddress}</p>
+        <p>{item.recipientPhone}</p>
+        <p className="break-words whitespace-pre-wrap">
+          {item.detailAddress || ' '}
+        </p>
+      </div>
+
+      <div className="mt-8 grid grid-cols-2 gap-4">
+        <Link
+          href={`/address/${item.addressId}`}
+          className="bg-ongil-teal flex h-16 items-center justify-center rounded-2xl text-xl font-semibold text-white"
+        >
+          수정
+        </Link>
+
+        <button
+          onClick={handleSetDefault}
+          disabled={item.isDefault || isSettingDefault}
+          className={`h-16 rounded-2xl text-xl font-semibold ${
+            item.isDefault
+              ? 'cursor-not-allowed bg-[#cfcfcf] text-[#666]'
+              : 'bg-[#cfcfcf] text-[#111]'
+          }`}
+        >
+          {isSettingDefault ? '선택 중...' : item.isDefault ? '선택됨' : '선택'}
         </button>
       </div>
     </div>

--- a/src/components/address/address-list.tsx
+++ b/src/components/address/address-list.tsx
@@ -1,25 +1,38 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { AddressItem as AddressItemType } from '@/types/domain/address';
 import AddressItem from './address-item';
 
 interface AddressListProps {
   addresses: AddressItemType[];
   showSelectButton?: boolean;
+  initialSelectedAddressId?: number | null;
 }
 
 export default function AddressList({
   addresses,
   showSelectButton = true,
+  initialSelectedAddressId,
 }: AddressListProps) {
-  const initialSelectedAddressId = useMemo(
-    () => addresses.find((addr) => addr.isDefault)?.addressId ?? null,
-    [addresses],
-  );
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const fallbackSelectedAddressId =
+    addresses.find((addr) => addr.isDefault)?.addressId ?? null;
   const [selectedAddressId, setSelectedAddressId] = useState<number | null>(
-    initialSelectedAddressId,
+    initialSelectedAddressId ?? fallbackSelectedAddressId,
   );
+
+  const handleSelect = (addressId: number) => {
+    setSelectedAddressId(addressId);
+
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.set('selectedAddressId', String(addressId));
+    router.replace(`${pathname}?${nextParams.toString()}`, { scroll: false });
+  };
 
   return (
     <div className="flex flex-col gap-4">
@@ -28,7 +41,7 @@ export default function AddressList({
           key={addr.addressId}
           item={addr}
           isSelected={selectedAddressId === addr.addressId}
-          onSelect={setSelectedAddressId}
+          onSelect={handleSelect}
           showSelectButton={showSelectButton}
         />
       ))}

--- a/src/components/address/address-list.tsx
+++ b/src/components/address/address-list.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { AddressItem as AddressItemType } from '@/types/domain/address';
+import AddressItem from './address-item';
+
+interface AddressListProps {
+  addresses: AddressItemType[];
+  showSelectButton?: boolean;
+}
+
+export default function AddressList({
+  addresses,
+  showSelectButton = true,
+}: AddressListProps) {
+  const initialSelectedAddressId = useMemo(
+    () => addresses.find((addr) => addr.isDefault)?.addressId ?? null,
+    [addresses],
+  );
+  const [selectedAddressId, setSelectedAddressId] = useState<number | null>(
+    initialSelectedAddressId,
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {addresses.map((addr) => (
+        <AddressItem
+          key={addr.addressId}
+          item={addr}
+          isSelected={selectedAddressId === addr.addressId}
+          onSelect={setSelectedAddressId}
+          showSelectButton={showSelectButton}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/address/address-page-footer.tsx
+++ b/src/components/address/address-page-footer.tsx
@@ -1,16 +1,45 @@
 'use client';
 
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 interface AddressPageFooterProps {
   isManageMode: boolean;
+  isSelectMode?: boolean;
+  returnTo?: string;
 }
 
 export default function AddressPageFooter({
   isManageMode,
+  isSelectMode = false,
+  returnTo,
 }: AddressPageFooterProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleCompleteSelection = () => {
+    const selectedAddressId = searchParams.get('selectedAddressId');
+
+    if (!selectedAddressId) {
+      if (!isSelectMode) {
+        router.back();
+        return;
+      }
+
+      alert('배송지를 선택해주세요.');
+      return;
+    }
+
+    if (isSelectMode && returnTo) {
+      const targetUrl = new URL(returnTo, window.location.origin);
+      targetUrl.searchParams.set('selectedAddressId', selectedAddressId);
+
+      router.replace(`${targetUrl.pathname}${targetUrl.search}`);
+      return;
+    }
+
+    router.back();
+  };
 
   return (
     <div className="fixed inset-x-0 bottom-0 bg-white p-5">
@@ -32,7 +61,7 @@ export default function AddressPageFooter({
             </Link>
             <button
               type="button"
-              onClick={() => router.back()}
+              onClick={handleCompleteSelection}
               className="bg-ongil-teal h-16 rounded-3xl text-xl font-bold text-white"
             >
               선택 완료

--- a/src/components/address/address-page-footer.tsx
+++ b/src/components/address/address-page-footer.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+interface AddressPageFooterProps {
+  isManageMode: boolean;
+}
+
+export default function AddressPageFooter({
+  isManageMode,
+}: AddressPageFooterProps) {
+  const router = useRouter();
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 bg-white p-5">
+      <div className="mx-auto w-full max-w-2xl">
+        {isManageMode ? (
+          <Link
+            href="/address/new"
+            className="bg-ongil-teal mx-auto flex h-16 items-center justify-center rounded-3xl text-xl font-bold text-white transition-opacity hover:opacity-90"
+          >
+            배송지 추가
+          </Link>
+        ) : (
+          <div className="grid grid-cols-2 gap-4">
+            <Link
+              href="/address/new"
+              className="flex h-16 items-center justify-center rounded-3xl border border-[#bdbdbd] bg-white text-xl font-bold text-[#111]"
+            >
+              배송지 추가
+            </Link>
+            <button
+              type="button"
+              onClick={() => router.back()}
+              className="bg-ongil-teal h-16 rounded-3xl text-xl font-bold text-white"
+            >
+              선택 완료
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/address/shipping-info-card-fetcher.tsx
+++ b/src/components/address/shipping-info-card-fetcher.tsx
@@ -1,23 +1,44 @@
-import { getAddresses } from '@/app/actions/address';
+import { getAddresses, getMyAddress } from '@/app/actions/address';
 import ShippingInfoCard from './shipping-info-card';
 
 interface ShippingInfoCardFetcherProps {
   title?: string;
   className?: string;
+  actionHref?: string;
+  actionLabel?: string;
 }
 
 export default async function ShippingInfoCardFetcher({
   title,
   className,
+  actionHref,
+  actionLabel,
 }: ShippingInfoCardFetcherProps) {
-  const addresses = await getAddresses();
+  const [addresses, myAddress] = await Promise.all([
+    getAddresses(),
+    getMyAddress().catch(() => null),
+  ]);
+
   const defaultAddress = addresses.find((item) => item.isDefault) || null;
+  const resolvedDefaultAddress =
+    defaultAddress &&
+    myAddress?.hasShippingInfo &&
+    myAddress.shippingDetail.addressId === defaultAddress.addressId
+      ? {
+          ...defaultAddress,
+          deliveryRequest:
+            myAddress.shippingDetail.deliveryRequest ||
+            defaultAddress.deliveryRequest,
+        }
+      : defaultAddress;
 
   return (
     <ShippingInfoCard
-      address={defaultAddress}
+      address={resolvedDefaultAddress}
       title={title}
       className={className}
+      actionHref={actionHref}
+      actionLabel={actionLabel}
     />
   );
 }

--- a/src/components/address/shipping-info-card-fetcher.tsx
+++ b/src/components/address/shipping-info-card-fetcher.tsx
@@ -1,0 +1,23 @@
+import { getAddresses } from '@/app/actions/address';
+import ShippingInfoCard from './shipping-info-card';
+
+interface ShippingInfoCardFetcherProps {
+  title?: string;
+  className?: string;
+}
+
+export default async function ShippingInfoCardFetcher({
+  title,
+  className,
+}: ShippingInfoCardFetcherProps) {
+  const addresses = await getAddresses();
+  const defaultAddress = addresses.find((item) => item.isDefault) || null;
+
+  return (
+    <ShippingInfoCard
+      address={defaultAddress}
+      title={title}
+      className={className}
+    />
+  );
+}

--- a/src/components/address/shipping-info-card.tsx
+++ b/src/components/address/shipping-info-card.tsx
@@ -23,11 +23,11 @@ export default function ShippingInfoCard({
 
       <div className="rounded-xl border border-[#cfcfcf] bg-white p-4">
         {address ? (
-          <div className="mb-5 flex flex-col gap-6 space-y-3 text-xl leading-normal text-black">
+          <div className="mb-5 flex flex-col gap-6 text-xl leading-normal text-black">
             <p>{address.recipientName}</p>
             <p>{address.baseAddress}</p>
             <p>{address.recipientPhone}</p>
-            <p className="wrap-break-words line-clamp-3 whitespace-pre-wrap">
+            <p className="wrap-break-word line-clamp-3 whitespace-pre-wrap">
               {address.detailAddress}
             </p>
           </div>

--- a/src/components/address/shipping-info-card.tsx
+++ b/src/components/address/shipping-info-card.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Link from 'next/link';
 import { AddressItem } from '@/types/domain/address';
 
@@ -27,7 +25,7 @@ export default function ShippingInfoCard({
             <p>{address.recipientName}</p>
             <p>{address.baseAddress}</p>
             <p>{address.recipientPhone}</p>
-            <p className="wrap-break-word line-clamp-3 whitespace-pre-wrap">
+            <p className="break-words whitespace-pre-wrap">
               {address.detailAddress}
             </p>
           </div>

--- a/src/components/address/shipping-info-card.tsx
+++ b/src/components/address/shipping-info-card.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { AddressItem } from '@/types/domain/address';
+
+interface ShippingInfoCardProps {
+  address: AddressItem | null;
+  title?: string;
+  className?: string;
+}
+
+export default function ShippingInfoCard({
+  address,
+  title = '배송지 정보',
+  className,
+}: ShippingInfoCardProps) {
+  const actionHref = address ? `/address/${address.addressId}` : '/address/new';
+  const actionLabel = address ? '배송지 수정하기' : '배송지 입력하기';
+
+  return (
+    <section className={className}>
+      <h2 className="mb-3 text-2xl">{title}</h2>
+
+      <div className="rounded-xl border border-[#cfcfcf] bg-white p-4">
+        {address ? (
+          <div className="mb-5 flex flex-col gap-6 space-y-3 text-xl leading-normal text-black">
+            <p>{address.recipientName}</p>
+            <p>{address.baseAddress}</p>
+            <p>{address.recipientPhone}</p>
+            <p className="wrap-break-words line-clamp-3 whitespace-pre-wrap">
+              {address.detailAddress}
+            </p>
+          </div>
+        ) : (
+          <div className="mb-5 flex min-h-[180px] items-center justify-center">
+            <p className="text-2xl text-[#9a9a9a]">배송지 정보가 없습니다</p>
+          </div>
+        )}
+
+        <Link
+          href={actionHref}
+          className="bg-ongil-teal mx-auto flex h-14 w-[260px] items-center justify-center rounded-xl px-5 text-xl font-medium text-white"
+        >
+          {actionLabel}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/src/components/address/shipping-info-card.tsx
+++ b/src/components/address/shipping-info-card.tsx
@@ -5,15 +5,21 @@ interface ShippingInfoCardProps {
   address: AddressItem | null;
   title?: string;
   className?: string;
+  actionHref?: string;
+  actionLabel?: string;
 }
 
 export default function ShippingInfoCard({
   address,
   title = '배송지 정보',
   className,
+  actionHref,
+  actionLabel,
 }: ShippingInfoCardProps) {
-  const actionHref = address ? `/address/${address.addressId}` : '/address/new';
-  const actionLabel = address ? '배송지 수정하기' : '배송지 입력하기';
+  const resolvedActionHref =
+    actionHref ?? (address ? `/address/${address.addressId}` : '/address/new');
+  const resolvedActionLabel =
+    actionLabel ?? (address ? '배송지 수정하기' : '배송지 입력하기');
 
   return (
     <section className={className}>
@@ -23,10 +29,14 @@ export default function ShippingInfoCard({
         {address ? (
           <div className="mb-5 flex flex-col gap-6 text-xl leading-normal text-black">
             <p>{address.recipientName}</p>
-            <p>{address.baseAddress}</p>
+            <p className="break-words whitespace-pre-wrap">
+              {[address.baseAddress, address.detailAddress]
+                .filter(Boolean)
+                .join(' ')}
+            </p>
             <p>{address.recipientPhone}</p>
             <p className="break-words whitespace-pre-wrap">
-              {address.detailAddress}
+              {address.deliveryRequest || '요청사항 없음'}
             </p>
           </div>
         ) : (
@@ -36,10 +46,10 @@ export default function ShippingInfoCard({
         )}
 
         <Link
-          href={actionHref}
+          href={resolvedActionHref}
           className="bg-ongil-teal mx-auto flex h-14 w-[260px] items-center justify-center rounded-xl px-5 text-xl font-medium text-white"
         >
-          {actionLabel}
+          {resolvedActionLabel}
         </Link>
       </div>
     </section>

--- a/src/components/mypage/edit-profile-photo-sheet.tsx
+++ b/src/components/mypage/edit-profile-photo-sheet.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { type ChangeEvent, useRef, useState } from 'react';
+import Image from 'next/image';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetTitle,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { updateProfileImageAction } from '@/app/actions/user';
+
+interface EditProfilePhotoSheetProps {
+  imageUrl: string | null;
+  userName: string;
+}
+
+function withCacheBuster(url: string | null): string | null {
+  if (!url) return null;
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}v=${Date.now()}`;
+}
+
+export default function EditProfilePhotoSheet({
+  imageUrl,
+  userName,
+}: EditProfilePhotoSheetProps) {
+  const [open, setOpen] = useState(false);
+  const [currentImageUrl, setCurrentImageUrl] = useState(
+    withCacheBuster(imageUrl),
+  );
+  const [isUploading, setIsUploading] = useState(false);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const galleryInputRef = useRef<HTMLInputElement>(null);
+
+  const handleUpload = async (file: File | null) => {
+    if (!file) return;
+
+    setIsUploading(true);
+    try {
+      const updatedUser = await updateProfileImageAction(file);
+      setCurrentImageUrl(withCacheBuster(updatedUser.profileUrl ?? null));
+      setOpen(false);
+      alert('프로필 이미지가 수정되었습니다.');
+    } catch (error) {
+      alert(
+        error instanceof Error
+          ? error.message
+          : '프로필 이미지 수정에 실패했습니다.',
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0] ?? null;
+    event.currentTarget.value = '';
+    await handleUpload(selectedFile);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <button
+            type="button"
+            aria-label="프로필 사진 수정"
+            className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-full bg-gray-100"
+          >
+            {currentImageUrl ? (
+              <Image
+                src={currentImageUrl}
+                alt="프로필 이미지"
+                width={96}
+                height={96}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <Image
+                src="/icons/profile.svg"
+                alt="기본 프로필"
+                width={56}
+                height={56}
+                className="h-14 w-14"
+              />
+            )}
+          </button>
+        </SheetTrigger>
+
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="rounded-t-2xl border-none bg-transparent p-4 shadow-none"
+        >
+          <SheetTitle className="sr-only">프로필 이미지 수정</SheetTitle>
+          <SheetDescription className="sr-only">
+            사진 찍기 또는 보관함에서 프로필 이미지를 선택합니다.
+          </SheetDescription>
+
+          <div className="overflow-hidden rounded-2xl bg-white">
+            <button
+              type="button"
+              disabled={isUploading}
+              onClick={() => cameraInputRef.current?.click()}
+              className="w-full py-5 text-4xl font-medium text-black"
+            >
+              사진 찍기
+            </button>
+            <div className="h-px bg-[#d9d9d9]" />
+            <button
+              type="button"
+              disabled={isUploading}
+              onClick={() => galleryInputRef.current?.click()}
+              className="w-full py-5 text-4xl font-medium text-black"
+            >
+              사진 보관함
+            </button>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            disabled={isUploading}
+            className="mt-4 w-full rounded-2xl bg-white py-5 text-4xl font-semibold text-black"
+          >
+            취소
+          </button>
+        </SheetContent>
+      </Sheet>
+
+      <input
+        ref={cameraInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleImageChange}
+      />
+      <input
+        ref={galleryInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleImageChange}
+      />
+
+      <span className="text-4xl font-semibold text-black">{userName}</span>
+    </div>
+  );
+}

--- a/src/components/product/size/body-info-form.tsx
+++ b/src/components/product/size/body-info-form.tsx
@@ -6,7 +6,6 @@ import {
   useForm,
   Control,
   Controller,
-  UseFormRegister,
   Path,
   FieldValues,
   FieldError,
@@ -70,7 +69,7 @@ const ICON_STYLE = cn(
 interface InputFieldProps<T extends FieldValues> {
   label: string;
   name: Path<T>;
-  register: UseFormRegister<T>;
+  control: Control<T>;
   unit: string;
   error?: FieldError;
   placeholder?: string;
@@ -80,30 +79,38 @@ interface InputFieldProps<T extends FieldValues> {
 const InputField = <T extends FieldValues>({
   label,
   name,
-  register,
+  control,
   unit,
   error,
   placeholder = '0',
 }: InputFieldProps<T>) => (
   <div className="space-y-2">
     <label className={STYLES.label}>{label}</label>
-    <div
-      className={cn(
-        STYLES.baseBox,
-        error ? STYLES.errorBorder : STYLES.normalBorder,
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <div
+          className={cn(
+            STYLES.baseBox,
+            error ? STYLES.errorBorder : STYLES.normalBorder,
+          )}
+        >
+          <input
+            type="number"
+            inputMode="numeric"
+            step="1"
+            placeholder={placeholder}
+            value={field.value ?? ''}
+            onChange={(event) => field.onChange(event.target.value)}
+            className="w-full bg-transparent text-right text-base outline-none placeholder:text-gray-400"
+          />
+          <span className="ml-2 text-base whitespace-nowrap text-gray-700">
+            {unit}
+          </span>
+        </div>
       )}
-    >
-      <input
-        type="number"
-        inputMode="decimal"
-        placeholder={placeholder}
-        {...register(name, { valueAsNumber: true })}
-        className="w-full bg-transparent text-right text-base outline-none placeholder:text-gray-400"
-      />
-      <span className="ml-2 text-base whitespace-nowrap text-gray-700">
-        {unit}
-      </span>
-    </div>
+    />
     {error && <p className="text-xs text-red-500">{error.message}</p>}
   </div>
 );
@@ -202,7 +209,6 @@ export function BodyInfoForm({ initialData, onSuccess }: BodyInfoFormProps) {
   };
 
   const {
-    register,
     control,
     handleSubmit,
     reset,
@@ -287,14 +293,14 @@ export function BodyInfoForm({ initialData, onSuccess }: BodyInfoFormProps) {
               label="키"
               name="height"
               unit="cm"
-              register={register}
+              control={control}
               error={errors.height}
             />
             <InputField
               label="몸무게"
               name="weight"
               unit="kg"
-              register={register}
+              control={control}
               error={errors.weight}
             />
           </div>

--- a/src/components/product/size/body-info-form.tsx
+++ b/src/components/product/size/body-info-form.tsx
@@ -179,7 +179,10 @@ interface BodyInfoFormProps {
 }
 
 // 체형 정보 입력/수정 폼 컴포넌트, 위에서 만든 컴포넌트를 조립.
-export function BodyInfoForm({ initialData, onSuccess }: BodyInfoFormProps) {
+export default function BodyInfoForm({
+  initialData,
+  onSuccess,
+}: BodyInfoFormProps) {
   const router = useRouter();
   const pathname = usePathname();
   const [isPending, startTransition] = useTransition();

--- a/src/components/product/size/body-info-form.tsx
+++ b/src/components/product/size/body-info-form.tsx
@@ -287,9 +287,9 @@ export default function BodyInfoForm({
     <>
       <form
         onSubmit={handleSubmit(onSubmit)}
-        className="flex h-full flex-col justify-between bg-white"
+        className="flex h-full flex-col justify-between overflow-hidden bg-white"
       >
-        <div className="scrollbar-hide flex-1 overflow-y-auto px-[55px] pb-10">
+        <div className="scrollbar-hide flex-1 overflow-y-auto overscroll-y-contain px-[55px] pb-10">
           {/* 키 / 몸무게 섹션 */}
           <div className="flex flex-col gap-[74px]">
             <InputField

--- a/src/components/product/size/body-info-modal.tsx
+++ b/src/components/product/size/body-info-modal.tsx
@@ -6,7 +6,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { BodyInfoForm } from './body-info-form';
+import BodyInfoForm from './body-info-form';
 import { UserBodyInfo } from '@/types/domain/size';
 
 interface BodyInfoModalProps {

--- a/src/components/ui/body-info-modal.tsx
+++ b/src/components/ui/body-info-modal.tsx
@@ -21,7 +21,7 @@ export function BodyInfoModal({ children }: { children: React.ReactNode }) {
   return (
     <Dialog defaultOpen={true} open={true} onOpenChange={handleOpenChange}>
       <DialogOverlay className="bg-white" />
-      <DialogContent className="h-screen w-screen max-w-full gap-0 rounded-none border-none bg-white p-0 shadow-none duration-200 [&>button]:hidden">
+      <DialogContent className="h-screen w-screen max-w-full gap-0 overscroll-none rounded-none border-none bg-white p-0 shadow-none duration-200 [&>button]:hidden">
         <DialogTitle className="sr-only">체형 정보 입력</DialogTitle>
         <DialogDescription className="sr-only">
           체형 정보를 입력하거나 수정하는 전체 화면입니다.

--- a/src/components/ui/close-button.tsx
+++ b/src/components/ui/close-button.tsx
@@ -3,12 +3,35 @@
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
-export function CloseButton() {
+interface CloseButtonProps {
+  href?: string;
+  replace?: boolean;
+}
+
+function navigateByMode(
+  router: ReturnType<typeof useRouter>,
+  href?: string,
+  replace?: boolean,
+) {
+  if (!href) {
+    router.back();
+    return;
+  }
+
+  if (replace) {
+    router.replace(href);
+    return;
+  }
+
+  router.push(href);
+}
+
+export function CloseButton({ href, replace = true }: CloseButtonProps) {
   const router = useRouter();
 
   return (
     <button
-      onClick={() => router.back()}
+      onClick={() => navigateByMode(router, href, replace)}
       className="-ml-2 flex h-10 w-10 items-center justify-center rounded-full hover:bg-gray-100"
     >
       <Image src="/icons/arrow.svg" width={37} height={37} alt="뒤로가기" />
@@ -16,12 +39,12 @@ export function CloseButton() {
   );
 }
 
-export function CloseXButton() {
+export function CloseXButton({ href, replace = true }: CloseButtonProps) {
   const router = useRouter();
 
   return (
     <button
-      onClick={() => router.back()}
+      onClick={() => navigateByMode(router, href, replace)}
       className="-ml-2 flex h-10 w-10 items-center justify-center rounded-full hover:bg-gray-100"
     >
       <Image src="/icons/X.svg" width={23} height={23} alt="닫기" />

--- a/src/types/domain/address.ts
+++ b/src/types/domain/address.ts
@@ -7,6 +7,7 @@ export interface AddressItem {
   detailAddress: string;
   postalCode: string;
   isDefault: boolean;
+  deliveryRequest?: string;
 }
 
 /** 배송지 등록/수정 요청 데이터 */

--- a/src/types/domain/address.ts
+++ b/src/types/domain/address.ts
@@ -1,0 +1,47 @@
+/** 배송지 목록 조회 아이템 */
+export interface AddressItem {
+  addressId: number;
+  recipientName: string;
+  recipientPhone: string;
+  baseAddress: string;
+  detailAddress: string;
+  postalCode: string;
+  isDefault: boolean;
+}
+
+/** 배송지 등록/수정 요청 데이터 */
+export interface AddressRequest {
+  recipientName: string;
+  baseAddress: string;
+  detailAddress: string;
+  postalCode: string;
+  phone: string;
+  deliveryRequest?: string;
+}
+
+/** 배송지 상세 정보  */
+export interface AddressDetail {
+  addressId: number;
+  recipientName: string;
+  address: string;
+  postalCode: string;
+  phone: string;
+  deliveryRequest?: string;
+}
+
+/** 배송지 등록/수정/조회 응답 래퍼 */
+export interface AddressResponseData {
+  hasShippingInfo: boolean;
+  shippingDetail: AddressDetail;
+}
+
+/** 주문 배송지 변경 요청 */
+export interface ChangeOrderAddressRequest {
+  addressId: number;
+}
+
+export interface ApiStatusResponse {
+  status: string;
+  timestamp: string;
+  data: string;
+}


### PR DESCRIPTION
## 📝 개요

이번 PR은 **마이페이지 내 정보 수정 플로우**와 **배송지 관리 플로우**를 중심으로, 실제 사용 중 발생하던 데이터 불일치/초기화 문제를 해결하고 화면 동작을 역할별로 분리한 작업입니다.

핵심 목표:

1. 마이페이지에서 내 정보 수정 동선 정리 (`/me/edit`, `/me/edit/body-info`)
2. 배송지 수정 시 상세주소/요청사항 값 유실 방지
3. 주소 목록 화면을 **관리 모드**와 **선택 모드**로 분리
4. 주문 취소 화면에서 주소 조회 실패 시에도 플로우가 죽지 않도록 안정화
5. 체형 정보 입력 반영 안정화 및 폼 export 구조 정리

관련 이슈 번호: #이슈번호

---

## 🚀 주요 변경 사항

### 1) 마이페이지 내 정보 수정 플로우 분리

- `/me/edit` 페이지 신설
- `/me/edit/body-info` 페이지 신설
- 체형정보 저장 후 `/me/edit`로 복귀하도록 wrapper 분리
- 뒤로가기 버튼(`CloseButton`)을 경로 기반 이동 지원으로 보강해서 히스토리 꼬임 완화

### 2) 프로필 이미지 수정 UI/서버 액션 추가

- 프로필 이미지 액션시트 컴포넌트 추가
- 카메라/보관함 업로드 진입점 추가
- 프로필 이미지 업데이트 서버 액션 연동 (`updateProfileImageAction`)
- 업로드 후 마이페이지 캐시 갱신(`revalidatePath`) 처리

### 3) 체형 정보 입력 안정화

- `BodyInfoForm`에서 키/몸무게 입력 반영 누락되던 이슈 수정
- 체형정보 폼 export를 default로 통일
- 관련 import 경로 일괄 정리 (`body-info/page`, `body-info-modal`, 각 wrapper)

### 4) 배송지 수정 데이터 유실 이슈 수정

- 배송지 수정 시 `deliveryRequest`(요청사항) untouched 상태에서 잘못 덮어쓰던 문제 수정
- 기본 배송지 설정 실패 시 주소 저장 성공/실패를 분리 안내(부분 성공 처리)
- 주소 상세 진입 시 기본배송지의 `deliveryRequest` 보정 로직 추가
- 주소 카드에서 상세주소 표시 방식 정리(기본주소+상세주소 결합)

### 5) 주소 목록 화면 모드 분리

- `/address`를 모드 기반으로 분리
  - `mode=manage`: 내정보 수정 진입용(선택 버튼 숨김)
  - 기본 모드: 선택 버튼 노출
- 선택/관리 모드에 따라 하단 CTA 다르게 제공
- `address-list` / `address-page-footer` 컴포넌트 추가

### 6) 주문 취소 주소 단계 안정화

- 주문 취소 페이지에서 `getAddresses()` 실패 시 빈 배열 fallback 처리
- 주소 API 장애 상황에서도 취소 플로우 렌더링 유지

---

## 🧪 테스트/검증 포인트

1. **마이페이지**

- `/me/edit` 진입 가능
- 배송지 수정하기 클릭 시 `/address?mode=manage` 이동
- 체형 수정 진입 후 저장 시 `/me/edit` 복귀

2. **배송지**

- `/address` 기본 모드: 선택 버튼 노출
- `/address?mode=manage`: 선택 버튼 숨김, 수정 버튼만 노출
- 배송지 수정 시 요청사항/상세주소가 임의 초기화되지 않는지 확인
- 기본 배송지 설정 실패 시 “주소 저장됨 + 기본 배송지 설정 실패” 안내 확인

3. **주문 취소**

- 주소 API 실패 상황에서도 `/orders/[orderId]/cancel` 화면 렌더링 유지되는지 확인

4. **체형 정보**

- 키/몸무게 변경 후 저장 시 반영 확인
- 내 정보 화면 표시 시 키(cm), 몸무게(kg) 단위 확인

---

## ⚠️ 참고 사항

- 이미지 호스트(`next.config.ts` remotePatterns) 관련 정리는 **후속 작업**으로 분리 예정

---

## ✅ 체크리스트

- [x] 코드 컨벤션 준수
- [x] 린트 통과
- [x] 주요 사용자 플로우 수동 검증
- [ ] 이미지 호스트 설정 후속 반영 (별도 PR)

---

## 이슈 해결 여부

Closes #이슈번호
