### PR TITLE
[FIX]: 주문취소 배송지 수정 동선 및 닫기 버튼 복귀 경로 정리

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,11 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+
+      {
+        protocol: 'https',
         hostname: 'image.msscdn.net',
       },
       {

--- a/next.config.ts
+++ b/next.config.ts
@@ -24,6 +24,22 @@ const nextConfig: NextConfig = {
         protocol: 'http',
         hostname: 'img1.kakaocdn.net', // 카카오 프로필 이미지 호스팅
       },
+      {
+        protocol: 'https',
+        hostname: 'image.msscdn.net',
+      },
+      {
+        protocol: 'https',
+        hostname: 'image.hmall.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'image.queenit.kr',
+      },
+      {
+        protocol: 'https',
+        hostname: 'img.a-bly.com',
+      },
     ],
   },
 

--- a/src/app/actions/address.ts
+++ b/src/app/actions/address.ts
@@ -135,7 +135,6 @@ export async function changeOrderShippingAddress(
       `/orders/${orderId}/delivery-address`,
       { addressId },
     );
-    revalidatePath(`/orders/${orderId}`);
   } catch (error) {
     rethrowNextError(error);
     console.error('주문 배송지 변경 실패:', error);

--- a/src/app/address/[addressId]/page.tsx
+++ b/src/app/address/[addressId]/page.tsx
@@ -46,7 +46,7 @@ export default async function AddressEditPage({
       <header className="relative flex items-center justify-center border-b py-4">
         <h1 className="text-lg font-bold">배송지 수정</h1>
         <div className="absolute right-5">
-          <CloseXButton href={closeHref} />
+          <CloseXButton href={closeHref} replace={true} />
         </div>
       </header>
 

--- a/src/app/address/[addressId]/page.tsx
+++ b/src/app/address/[addressId]/page.tsx
@@ -15,7 +15,13 @@ export default async function AddressEditPage({
   const { addressId } = await params;
   const { returnTo } = await searchParams;
   const id = Number(addressId);
-  const closeHref = returnTo?.startsWith('/') ? returnTo : '/address';
+  const isOrderCancelReturn =
+    returnTo?.startsWith('/orders/') && returnTo.includes('/cancel');
+  const closeHref = isOrderCancelReturn
+    ? '/orders'
+    : returnTo?.startsWith('/')
+      ? returnTo
+      : '/address';
 
   if (Number.isNaN(id)) notFound();
 

--- a/src/app/address/[addressId]/page.tsx
+++ b/src/app/address/[addressId]/page.tsx
@@ -5,11 +5,17 @@ import { CloseXButton } from '@/components/ui/close-button';
 
 interface PageProps {
   params: Promise<{ addressId: string }>;
+  searchParams: Promise<{ returnTo?: string }>;
 }
 
-export default async function AddressEditPage({ params }: PageProps) {
+export default async function AddressEditPage({
+  params,
+  searchParams,
+}: PageProps) {
   const { addressId } = await params;
+  const { returnTo } = await searchParams;
   const id = Number(addressId);
+  const closeHref = returnTo?.startsWith('/') ? returnTo : '/address';
 
   if (Number.isNaN(id)) notFound();
 
@@ -40,7 +46,7 @@ export default async function AddressEditPage({ params }: PageProps) {
       <header className="relative flex items-center justify-center border-b py-4">
         <h1 className="text-lg font-bold">배송지 수정</h1>
         <div className="absolute right-5">
-          <CloseXButton />
+          <CloseXButton href={closeHref} />
         </div>
       </header>
 

--- a/src/app/address/new/page.tsx
+++ b/src/app/address/new/page.tsx
@@ -1,13 +1,22 @@
 import AddressForm from '@/components/address/address-form';
 import { CloseXButton } from '@/components/ui/close-button';
 
-export default function NewAddressPage() {
+interface NewAddressPageProps {
+  searchParams: Promise<{ returnTo?: string }>;
+}
+
+export default async function NewAddressPage({
+  searchParams,
+}: NewAddressPageProps) {
+  const { returnTo } = await searchParams;
+  const closeHref = returnTo?.startsWith('/') ? returnTo : '/address';
+
   return (
     <main className="mx-auto min-h-screen max-w-2xl bg-white leading-normal">
       <header className="relative flex items-center justify-center border-b py-4">
         <h1 className="text-lg font-bold">배송지 추가</h1>
         <div className="absolute right-5">
-          <CloseXButton />
+          <CloseXButton href={closeHref} />
         </div>
       </header>
 

--- a/src/app/address/new/page.tsx
+++ b/src/app/address/new/page.tsx
@@ -16,7 +16,7 @@ export default async function NewAddressPage({
       <header className="relative flex items-center justify-center border-b py-4">
         <h1 className="text-lg font-bold">배송지 추가</h1>
         <div className="absolute right-5">
-          <CloseXButton href={closeHref} />
+          <CloseXButton href={closeHref} replace={true} />
         </div>
       </header>
 

--- a/src/app/address/new/page.tsx
+++ b/src/app/address/new/page.tsx
@@ -9,7 +9,13 @@ export default async function NewAddressPage({
   searchParams,
 }: NewAddressPageProps) {
   const { returnTo } = await searchParams;
-  const closeHref = returnTo?.startsWith('/') ? returnTo : '/address';
+  const isOrderCancelReturn =
+    returnTo?.startsWith('/orders/') && returnTo.includes('/cancel');
+  const closeHref = isOrderCancelReturn
+    ? '/orders'
+    : returnTo?.startsWith('/')
+      ? returnTo
+      : '/address';
 
   return (
     <main className="mx-auto min-h-screen max-w-2xl bg-white leading-normal">

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -58,7 +58,7 @@ export default async function AddressListPage({
       <header className="sticky top-0 z-10 flex items-center justify-center border-b border-gray-500 bg-white py-4">
         <h1 className="text-2xl font-bold">배송지 관리</h1>
         <div className="absolute top-1/2 left-5 -translate-y-1/2">
-          <CloseButton href={closeHref} replace={isSelectMode} />
+          <CloseButton href={closeHref} replace={!!closeHref} />
         </div>
       </header>
 

--- a/src/app/address/page.tsx
+++ b/src/app/address/page.tsx
@@ -1,4 +1,5 @@
 import { getAddresses, getMyAddress } from '@/app/actions/address';
+import { Suspense } from 'react';
 import AddressList from '@/components/address/address-list';
 import AddressPageFooter from '@/components/address/address-page-footer';
 import { CloseButton } from '@/components/ui/close-button';
@@ -68,11 +69,19 @@ export default async function AddressListPage({
             <p className="mt-1 text-xl">새로운 배송지를 추가해 주세요.</p>
           </div>
         ) : (
-          <AddressList
-            addresses={resolvedAddresses}
-            showSelectButton={!isManageMode}
-            initialSelectedAddressId={initialSelectedAddressId}
-          />
+          <Suspense
+            fallback={
+              <div className="flex h-60 items-center justify-center rounded-3xl border border-[#bdbdbd] bg-white text-gray-500">
+                배송지 목록을 불러오는 중입니다.
+              </div>
+            }
+          >
+            <AddressList
+              addresses={resolvedAddresses}
+              showSelectButton={!isManageMode}
+              initialSelectedAddressId={initialSelectedAddressId}
+            />
+          </Suspense>
         )}
       </div>
 

--- a/src/app/me/edit/body-info/page.tsx
+++ b/src/app/me/edit/body-info/page.tsx
@@ -11,7 +11,7 @@ export default async function MyEditBodyInfoPage() {
     <div className="flex min-h-[100dvh] items-center justify-center overscroll-none bg-gray-50">
       <div className="flex h-[100dvh] w-full max-w-md flex-col overflow-hidden bg-white shadow-lg sm:rounded-2xl">
         <div className="flex h-16 shrink-0 items-center gap-6 px-5">
-          <CloseButton href="/me/edit" />
+          <CloseButton href="/me/edit" replace={true} />
           <h1 className="flex-1 pr-10 text-center text-2xl font-semibold">
             내 체형 정보 수정
           </h1>

--- a/src/app/me/edit/page.tsx
+++ b/src/app/me/edit/page.tsx
@@ -26,7 +26,7 @@ export default async function MyEditPage() {
       <header className="sticky top-0 z-10 flex items-center justify-center border-b border-[#d9d9d9] bg-white py-4">
         <h1 className="text-3xl font-semibold">내 정보 관리</h1>
         <div className="absolute top-1/2 left-5 -translate-y-1/2">
-          <CloseButton href="/me" />
+          <CloseButton href="/me" replace={true} />
         </div>
       </header>
 

--- a/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
+++ b/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
@@ -82,6 +82,7 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
   const searchParams = useSearchParams();
   const orderId = orderDetail.id;
   const selectedAddressIdParam = searchParams.get('selectedAddressId');
+  const urlStep = searchParams.get('step');
   const selectedAddressId = selectedAddressIdParam
     ? Number(selectedAddressIdParam)
     : null;
@@ -97,10 +98,10 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
     : `/orders/${orderId}`;
 
   const [step, setStep] = useState<Step>(
-    searchParams.get('step') === 'address' ? 'address' : 'reason',
+    urlStep === 'address' ? 'address' : 'reason',
   );
   const [selectedReason, setSelectedReason] = useState<string | null>(
-    searchParams.get('step') === 'address' ? 'WRONG_ADDRESS' : null,
+    urlStep === 'address' ? 'WRONG_ADDRESS' : null,
   );
   const [detail, setDetail] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -127,6 +128,17 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
 
   const alertRef = useFocusTrap(!!alertMessage);
   const confirmRef = useFocusTrap(showModal);
+
+  useEffect(() => {
+    if (urlStep === 'address') {
+      setStep('address');
+      setSelectedReason('WRONG_ADDRESS');
+      return;
+    }
+
+    setStep('reason');
+    setSelectedReason(null);
+  }, [urlStep]);
 
   useEffect(() => {
     if (step !== 'confirm') return;

--- a/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
+++ b/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
@@ -89,8 +89,8 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
     selectedAddressId !== null &&
     Number.isInteger(selectedAddressId) &&
     selectedAddressId > 0;
-  const returnToOrderDetail = `/orders/${orderId}`;
-  const encodedReturnTo = encodeURIComponent(returnToOrderDetail);
+  const returnToCancelAddressStep = `/orders/${orderId}/cancel?step=address`;
+  const encodedReturnTo = encodeURIComponent(returnToCancelAddressStep);
   const addressListHref = `/address?mode=select&returnTo=${encodedReturnTo}`;
   const orderDetailHref = hasSelectedAddressId
     ? `/orders/${orderId}?selectedAddressId=${selectedAddressId}`

--- a/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
+++ b/src/app/orders/[orderId]/cancel/_components/cancel-form.tsx
@@ -86,7 +86,9 @@ export function CancelForm({ orderDetail, defaultAddress }: CancelFormProps) {
     ? Number(selectedAddressIdParam)
     : null;
   const hasSelectedAddressId =
-    selectedAddressId !== null && !Number.isNaN(selectedAddressId);
+    selectedAddressId !== null &&
+    Number.isInteger(selectedAddressId) &&
+    selectedAddressId > 0;
   const returnToOrderDetail = `/orders/${orderId}`;
   const encodedReturnTo = encodeURIComponent(returnToOrderDetail);
   const addressListHref = `/address?mode=select&returnTo=${encodedReturnTo}`;

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -38,7 +38,7 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
       <header className="relative flex items-center justify-center py-8">
         <h1 className="text-3xl font-semibold">주문 취소</h1>
         <div className="absolute right-5">
-          <CloseXButton />
+          <CloseXButton fallbackHref="/orders" />
         </div>
       </header>
 

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -39,7 +39,7 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
       <header className="relative flex items-center justify-center py-8">
         <h1 className="text-3xl font-semibold">주문 취소</h1>
         <div className="absolute right-5">
-          <CloseXButton fallbackHref="/orders" />
+          <CloseXButton href="/orders" replace={true} />
         </div>
       </header>
 

--- a/src/app/orders/[orderId]/cancel/page.tsx
+++ b/src/app/orders/[orderId]/cancel/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next';
+import { Suspense } from 'react';
 import { getOrderDetail } from '@/app/actions/order';
 import { getAddresses } from '@/app/actions/address';
 import { notFound } from 'next/navigation';
@@ -42,7 +43,15 @@ export default async function CancelReasonPage({ params }: CancelPageProps) {
         </div>
       </header>
 
-      <CancelForm orderDetail={orderDetail} defaultAddress={defaultAddress} />
+      <Suspense
+        fallback={
+          <div className="flex min-h-[50vh] items-center justify-center text-gray-500">
+            불러오는 중...
+          </div>
+        }
+      >
+        <CancelForm orderDetail={orderDetail} defaultAddress={defaultAddress} />
+      </Suspense>
     </div>
   );
 }

--- a/src/app/orders/[orderId]/page.tsx
+++ b/src/app/orders/[orderId]/page.tsx
@@ -87,7 +87,7 @@ export default async function OrderDetailPage({
       <header className="flex items-center justify-center py-8">
         <h1 className="text-3xl font-semibold">주문 상세</h1>
         <div className="absolute right-5">
-          <CloseXButton href="/orders" />
+          <CloseXButton href="/orders" replace={true} />
         </div>
       </header>
       {showAddressUpdateError ? (

--- a/src/app/orders/[orderId]/page.tsx
+++ b/src/app/orders/[orderId]/page.tsx
@@ -47,12 +47,16 @@ export default async function OrderDetailPage({
     Number.isInteger(selectedAddressId) &&
     selectedAddressId > 0
   ) {
+    let addressChanged = false;
     try {
       await changeOrderShippingAddress(numericId, selectedAddressId);
-      redirect(`/orders/${numericId}`);
+      addressChanged = true;
     } catch (error) {
       console.error('주문 배송지 변경 실패:', error);
       redirect(`/orders/${numericId}?addressUpdateError=1`);
+    }
+    if (addressChanged) {
+      redirect(`/orders/${numericId}`);
     }
   }
 

--- a/src/app/payment/_components/step-navigator.tsx
+++ b/src/app/payment/_components/step-navigator.tsx
@@ -43,7 +43,7 @@ export default function StepNavigator({ activeStep, onStepChange }: Props) {
       <header className="fixed top-0 z-50 w-full max-w-md bg-white backdrop-blur-md">
         {/* 1. 타이틀 바 */}
         <div className="mt-8 flex h-14 items-center gap-4 px-6">
-          <CloseButton href={backHref} />
+          <CloseButton href={backHref} replace={true} />
           <h1 className="flex-1 pr-8 text-center text-3xl leading-normal font-semibold">
             주문/결제
           </h1>

--- a/src/app/payment/_components/step-navigator.tsx
+++ b/src/app/payment/_components/step-navigator.tsx
@@ -20,12 +20,15 @@ export default function StepNavigator({ activeStep, onStepChange }: Props) {
   ];
 
   const productId = searchParams.get('productId');
+  const from = searchParams.get('from');
   const backHref =
     searchParams.get('cart') === 'true'
       ? '/cart'
-      : productId
-        ? `/product/${productId}`
-        : undefined;
+      : from?.startsWith('/')
+        ? from
+        : productId
+          ? `/product/${productId}`
+          : undefined;
 
   // 현재 활성 단계 계산 (activeStep이 비어있으면 첫 번째 단계로 간주)
   const currentId = activeStep || steps[0].id;

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -7,10 +7,15 @@ import { getMyWishlist } from '@/app/actions/wishlist';
 
 interface PageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{ from?: string | string[] }>;
 }
 
-export default async function ProductPage({ params }: PageProps) {
+export default async function ProductPage({ params, searchParams }: PageProps) {
   const { id } = await params;
+  const resolvedSearchParams = await searchParams;
+  const backHref = Array.isArray(resolvedSearchParams.from)
+    ? resolvedSearchParams.from[0]
+    : resolvedSearchParams.from;
   const productId = Number(id);
 
   // 1. 상품 상세 + 부가 데이터 병렬 조회
@@ -48,6 +53,7 @@ export default async function ProductPage({ params }: PageProps) {
       similarProducts={similarProducts}
       userInfo={userInfo}
       analysisData={analysisData}
+      backHref={backHref}
       isLiked={isLiked}
       wishlistId={wishlistId}
     />

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -23,9 +23,17 @@ export default function AddressItem({
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const [isDeleting, setIsDeleting] = useState(false);
+  const mode = searchParams.get('mode');
+  const returnTo = searchParams.get('returnTo');
   const currentQuery = searchParams.toString();
-  const editHref = currentQuery
-    ? `/address/${item.addressId}?returnTo=${encodeURIComponent(`${pathname}?${currentQuery}`)}`
+  const editReturnTo =
+    mode === 'select' && returnTo?.startsWith('/')
+      ? returnTo
+      : currentQuery
+        ? `${pathname}?${currentQuery}`
+        : undefined;
+  const editHref = editReturnTo
+    ? `/address/${item.addressId}?returnTo=${encodeURIComponent(editReturnTo)}`
     : `/address/${item.addressId}`;
 
   const handleDelete = async () => {

--- a/src/components/address/address-item.tsx
+++ b/src/components/address/address-item.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { deleteAddress } from '@/app/actions/address';
 import { AddressItem as AddressItemType } from '@/types/domain/address';
 
@@ -20,7 +20,13 @@ export default function AddressItem({
   showSelectButton = true,
 }: AddressItemProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [isDeleting, setIsDeleting] = useState(false);
+  const currentQuery = searchParams.toString();
+  const editHref = currentQuery
+    ? `/address/${item.addressId}?returnTo=${encodeURIComponent(`${pathname}?${currentQuery}`)}`
+    : `/address/${item.addressId}`;
 
   const handleDelete = async () => {
     if (!confirm('정말 이 배송지를 삭제하시겠습니까?')) return;
@@ -79,7 +85,7 @@ export default function AddressItem({
         }`}
       >
         <Link
-          href={`/address/${item.addressId}`}
+          href={editHref}
           className="bg-ongil-teal flex h-16 items-center justify-center rounded-2xl text-xl font-semibold text-white"
         >
           수정

--- a/src/components/address/address-page-footer.tsx
+++ b/src/components/address/address-page-footer.tsx
@@ -16,6 +16,11 @@ export default function AddressPageFooter({
 }: AddressPageFooterProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const nextAddressParams = new URLSearchParams(searchParams.toString());
+  nextAddressParams.delete('selectedAddressId');
+  const newAddressHref = nextAddressParams.toString()
+    ? `/address/new?${nextAddressParams.toString()}`
+    : '/address/new';
 
   const handleCompleteSelection = () => {
     const selectedAddressId = searchParams.get('selectedAddressId');
@@ -46,7 +51,7 @@ export default function AddressPageFooter({
       <div className="mx-auto w-full max-w-2xl">
         {isManageMode ? (
           <Link
-            href="/address/new"
+            href={newAddressHref}
             className="bg-ongil-teal mx-auto flex h-16 items-center justify-center rounded-3xl text-xl font-bold text-white transition-opacity hover:opacity-90"
           >
             배송지 추가
@@ -54,7 +59,7 @@ export default function AddressPageFooter({
         ) : (
           <div className="grid grid-cols-2 gap-4">
             <Link
-              href="/address/new"
+              href={newAddressHref}
               className="flex h-16 items-center justify-center rounded-3xl border border-[#bdbdbd] bg-white text-xl font-bold text-[#111]"
             >
               배송지 추가

--- a/src/components/orders/order-list-card.tsx
+++ b/src/components/orders/order-list-card.tsx
@@ -10,6 +10,7 @@ import { OrderStatus } from '@/types/enums';
 
 const STATUS_LABEL: Record<OrderStatus, string> = {
   [OrderStatus.ORDER_RECEIVED]: '주문 완료',
+  [OrderStatus.ORDER_CONFIRMED]: '주문 확정',
   [OrderStatus.CANCELED]: '주문 취소',
 };
 
@@ -25,10 +26,10 @@ export default function OrderListCard({
   const router = useRouter();
   const repItem = order.items[0];
   const [showAlert, setShowAlert] = useState(false);
-  const isCanceled = order.orderStatus === OrderStatus.CANCELED;
+  const canCancel = order.orderStatus === OrderStatus.ORDER_RECEIVED;
 
   const handleCancelClick = () => {
-    if (isCanceled) {
+    if (!canCancel) {
       setShowAlert(true);
     } else {
       router.push(`/orders/${order.orderId}/cancel`);
@@ -104,7 +105,9 @@ export default function OrderListCard({
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="mx-5 w-full max-w-md rounded-2xl bg-white p-6">
             <p className="mb-6 text-center text-xl font-bold">
-              이미 취소된 주문입니다.
+              {order.orderStatus === OrderStatus.CANCELED
+                ? '이미 취소된 주문입니다.'
+                : '주문 확정 상태에서는 취소할 수 없습니다.'}
             </p>
             <button
               className="bg-ongil-teal w-full rounded-xl py-3 text-lg text-white"

--- a/src/components/orders/order-list-card.tsx
+++ b/src/components/orders/order-list-card.tsx
@@ -15,9 +15,13 @@ const STATUS_LABEL: Record<OrderStatus, string> = {
 
 interface OrderListCardProps {
   order: OrderSummary;
+  hideActions?: boolean;
 }
 
-export default function OrderListCard({ order }: OrderListCardProps) {
+export default function OrderListCard({
+  order,
+  hideActions = false,
+}: OrderListCardProps) {
   const router = useRouter();
   const repItem = order.items[0];
   const [showAlert, setShowAlert] = useState(false);
@@ -67,29 +71,33 @@ export default function OrderListCard({ order }: OrderListCardProps) {
           </div>
         </div>
 
-        {/* 문의하기 링크 */}
-        <div className="my-8 flex justify-end">
-          <button className="flex items-center leading-[18px] font-medium text-[#999999] transition-colors">
-            상품 문의하기 &gt;
-          </button>
-        </div>
+        {hideActions ? null : (
+          <>
+            {/* 문의하기 링크 */}
+            <div className="my-8 flex justify-end">
+              <button className="flex items-center leading-[18px] font-medium text-[#999999] transition-colors">
+                상품 문의하기 &gt;
+              </button>
+            </div>
 
-        {/* 하단 버튼 그룹 */}
-        <div className="grid h-[46px] grid-cols-2 gap-[14px] text-xl leading-normal font-medium -tracking-[0.6px]">
-          <Button
-            variant="outline"
-            className="h-full rounded-md bg-[#C1C1C1] text-xl"
-            onClick={handleCancelClick}
-          >
-            <span>상품 취소하기</span>
-          </Button>
-          <Button
-            className="bg-ongil-teal h-full rounded-md text-xl text-white"
-            onClick={() => router.push(`/orders/${order.orderId}`)}
-          >
-            <span>주문 상세 보기</span>
-          </Button>
-        </div>
+            {/* 하단 버튼 그룹 */}
+            <div className="grid h-[46px] grid-cols-2 gap-[14px] text-xl leading-normal font-medium -tracking-[0.6px]">
+              <Button
+                variant="outline"
+                className="h-full rounded-md bg-[#C1C1C1] text-xl"
+                onClick={handleCancelClick}
+              >
+                <span>상품 취소하기</span>
+              </Button>
+              <Button
+                className="bg-ongil-teal h-full rounded-md text-xl text-white"
+                onClick={() => router.push(`/orders/${order.orderId}`)}
+              >
+                <span>주문 상세 보기</span>
+              </Button>
+            </div>
+          </>
+        )}
       </CardContent>
 
       {showAlert && (

--- a/src/components/orders/order-list-card.tsx
+++ b/src/components/orders/order-list-card.tsx
@@ -59,8 +59,10 @@ export default function OrderListCard({
             alt={repItem?.productName || '상품 이미지'}
             width={110}
             height={110}
+            className="h-40 w-30 shrink-0 object-contain"
           />
           <div className="flex flex-col gap-6 text-xl leading-[18px] font-medium">
+            <span>{repItem?.brandName}</span>
             <span>{repItem?.productName}</span>
             <span>
               {repItem?.selectedColor} / {repItem?.selectedSize}

--- a/src/components/product-option-sheet/use-product-option.ts
+++ b/src/components/product-option-sheet/use-product-option.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback, useTransition } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { ProductOption } from '@/types/domain/product';
 import { addToCart } from '@/app/actions/cart';
 import { useCartStore } from '@/store/cart';
@@ -31,6 +31,8 @@ export default function useProductOption({
   onOpenChange: externalOnOpenChange,
 }: UseProductOptionProps) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const { fetchCount } = useCartStore();
   const [isPending, startTransition] = useTransition();
 
@@ -163,6 +165,11 @@ export default function useProductOption({
             productId: String(productId),
             selections: JSON.stringify(selections),
           });
+          const currentSearch = searchParams.toString();
+          const currentPath = currentSearch
+            ? `${pathname}?${currentSearch}`
+            : pathname;
+          params.set('from', currentPath);
 
           setIsOpen(false);
           setSelectedItems([]);

--- a/src/components/product/product-card.tsx
+++ b/src/components/product/product-card.tsx
@@ -4,11 +4,16 @@ import { Product } from '@/types/domain/product';
 // 카드 UI 컴포넌트, 클릭 시 상세 페이지로 이동함.
 interface ProductCardProps {
   product: Product;
+  detailFrom?: string;
 }
 
-export default function ProductCard({ product }: ProductCardProps) {
+export default function ProductCard({ product, detailFrom }: ProductCardProps) {
+  const href = detailFrom
+    ? `/product/${product.id}?from=${encodeURIComponent(detailFrom)}`
+    : `/product/${product.id}`;
+
   return (
-    <Link href={`/product/${product.id}`} className="block">
+    <Link href={href} className="block">
       <div className="font-pretendard flex w-41 flex-col gap-1">
         <img
           src={product.thumbnailImageUrl}

--- a/src/components/product/product-detail-view.tsx
+++ b/src/components/product/product-detail-view.tsx
@@ -52,6 +52,7 @@ interface ProductDetailViewProps {
   similarProducts: Product[];
   userInfo: UserBodyInfo | null;
   analysisData: SizeAnalysisResult | null;
+  backHref?: string;
   isLiked?: boolean;
   wishlistId?: number;
 }
@@ -61,6 +62,7 @@ export default function ProductDetailView({
   similarProducts,
   userInfo,
   analysisData,
+  backHref,
   isLiked = false,
   wishlistId,
 }: ProductDetailViewProps) {
@@ -109,7 +111,7 @@ export default function ProductDetailView({
   return (
     <div className="relative min-h-screen bg-white pb-32">
       <ProductInteractionProvider key={product.id}>
-        <ProductHeader categoryID={product.categoryId} />
+        <ProductHeader categoryID={product.categoryId} backHref={backHref} />
 
         {/* 상단: 이미지 슬라이더 & 기본 정보 */}
         <ProductImageSlider

--- a/src/components/product/product-header.tsx
+++ b/src/components/product/product-header.tsx
@@ -7,6 +7,7 @@ import { CartCountBadge } from '@/components/cart/cart-count-badge';
 
 interface ProductHeaderProps {
   categoryID: string | number | undefined;
+  backHref?: string;
   initialCartCount?: number;
 }
 
@@ -17,12 +18,15 @@ interface ProductHeaderProps {
  * @param {number} props.initialCartCount - 초기 장바구니 담긴 개수 (SSR)
  * @returns {JSX.Element} 상품 헤더 컴포넌트
  */
-export default function ProductHeader({ categoryID }: ProductHeaderProps) {
-  const backLink = categoryID ? `/products/${categoryID}` : '/products/top-all';
+export default function ProductHeader({
+  categoryID,
+  backHref,
+}: ProductHeaderProps) {
+  const backLink = backHref || (categoryID ? `/category` : '/category');
 
   return (
     <header className="sticky top-0 z-50 flex h-[90px] w-full items-center justify-between bg-white px-[18px]">
-      <CloseButton />
+      <CloseButton href={backLink} replace={true} />
       <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl font-semibold">
         상품 정보
       </span>

--- a/src/components/product/product-header.tsx
+++ b/src/components/product/product-header.tsx
@@ -22,12 +22,15 @@ export default function ProductHeader({
   categoryID,
   backHref,
 }: ProductHeaderProps) {
-  const backLink =
-    backHref || (categoryID ? `/category/${categoryID}` : '/category');
+  const fallback = categoryID ? `/category/${categoryID}` : '/category';
 
   return (
     <header className="sticky top-0 z-50 flex h-[90px] w-full items-center justify-between bg-white px-[18px]">
-      <CloseButton href={backLink} replace={true} />
+      {backHref ? (
+        <CloseButton href={backHref} replace={true} />
+      ) : (
+        <CloseButton fallbackHref={fallback} />
+      )}
       <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-3xl font-semibold">
         상품 정보
       </span>

--- a/src/components/product/product-header.tsx
+++ b/src/components/product/product-header.tsx
@@ -22,7 +22,8 @@ export default function ProductHeader({
   categoryID,
   backHref,
 }: ProductHeaderProps) {
-  const backLink = backHref || (categoryID ? `/category` : '/category');
+  const backLink =
+    backHref || (categoryID ? `/category/${categoryID}` : '/category');
 
   return (
     <header className="sticky top-0 z-50 flex h-[90px] w-full items-center justify-between bg-white px-[18px]">

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -12,7 +12,7 @@ export default async function ProductListContainer({
   params,
   searchParams,
 }: ProductListContainerProps) {
-  const { id: subCategoryId } = await params;
+  const { parentId, id: subCategoryId } = await params;
   const { sortType = ProductSortType.POPULAR, page = '0' } = await searchParams;
 
   // 쿼리 파라미터 검증
@@ -50,6 +50,7 @@ export default async function ProductListContainer({
     <ProductList
       products={result.products.content}
       totalElements={totalElements}
+      productDetailFrom={`/category/${parentId}/${subCategoryId}`}
     />
   );
 }

--- a/src/components/product/product-list.tsx
+++ b/src/components/product/product-list.tsx
@@ -7,9 +7,14 @@ interface ProductListProps {
   products: Product[];
   title?: string;
   totalElements?: number;
+  productDetailFrom?: string;
 }
 
-export function ProductList({ products, totalElements }: ProductListProps) {
+export function ProductList({
+  products,
+  totalElements,
+  productDetailFrom,
+}: ProductListProps) {
   const count = totalElements ?? products.length;
 
   return (
@@ -28,7 +33,11 @@ export function ProductList({ products, totalElements }: ProductListProps) {
         ) : (
           <div className="grid grid-cols-2 gap-x-4 gap-y-8 sm:grid-cols-3 lg:grid-cols-4">
             {products.map((product) => (
-              <ProductCard key={product.id} product={product} />
+              <ProductCard
+                key={product.id}
+                product={product}
+                detailFrom={productDetailFrom}
+              />
             ))}
           </div>
         )}

--- a/src/components/ui/close-button.tsx
+++ b/src/components/ui/close-button.tsx
@@ -6,32 +6,49 @@ import Image from 'next/image';
 interface CloseButtonProps {
   href?: string;
   replace?: boolean;
+  fallbackHref?: string;
 }
 
 function navigateByMode(
   router: ReturnType<typeof useRouter>,
   href?: string,
   replace?: boolean,
+  fallbackHref?: string,
 ) {
-  if (!href) {
+  if (href) {
+    if (replace) {
+      router.replace(href);
+      return;
+    }
+
+    router.push(href);
+    return;
+  }
+
+  if (typeof window !== 'undefined' && window.history.length > 1) {
     router.back();
     return;
   }
 
-  if (replace) {
-    router.replace(href);
+  if (fallbackHref) {
+    router.replace(fallbackHref);
     return;
   }
 
-  router.push(href);
+  router.back();
 }
 
-export function CloseButton({ href, replace = true }: CloseButtonProps) {
+export function CloseButton({
+  href,
+  replace = false,
+  fallbackHref,
+}: CloseButtonProps) {
   const router = useRouter();
 
   return (
     <button
-      onClick={() => navigateByMode(router, href, replace)}
+      type="button"
+      onClick={() => navigateByMode(router, href, replace, fallbackHref)}
       className="-ml-2 flex h-10 w-10 items-center justify-center rounded-full hover:bg-gray-100"
     >
       <Image src="/icons/arrow.svg" width={37} height={37} alt="뒤로가기" />
@@ -39,12 +56,17 @@ export function CloseButton({ href, replace = true }: CloseButtonProps) {
   );
 }
 
-export function CloseXButton({ href, replace = true }: CloseButtonProps) {
+export function CloseXButton({
+  href,
+  replace = false,
+  fallbackHref,
+}: CloseButtonProps) {
   const router = useRouter();
 
   return (
     <button
-      onClick={() => navigateByMode(router, href, replace)}
+      type="button"
+      onClick={() => navigateByMode(router, href, replace, fallbackHref)}
       className="-ml-2 flex h-10 w-10 items-center justify-center rounded-full hover:bg-gray-100"
     >
       <Image src="/icons/X.svg" width={23} height={23} alt="닫기" />

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -25,6 +25,7 @@ export enum CategoryType {
 // Order
 export enum OrderStatus {
   ORDER_RECEIVED = 'ORDER_RECEIVED',
+  ORDER_CONFIRMED = 'CONFIRMED',
   CANCELED = 'CANCELED',
 }
 


### PR DESCRIPTION
## 📝 개요

주문 취소 화면의 `배송지 잘못 입력` 분기에서 발생하던 이동 경로 불일치를 정리하고,  
배송지 선택/수정 결과가 실제 주문 상세에 반영되는 흐름으로 일관화한 작업입니다.

기존에는 주소 수정/선택 이후에도 취소 플로우로 되돌아가거나, 닫기 버튼(`X`) 동작이 화면마다 달라 사용자가 맥락을 잃는 문제가 있었습니다.  
이번 PR은 `선택 → 반영 → 결과 확인`의 흐름을 기준으로 내비게이션을 재설계했습니다.

관련 이슈 번호: #이슈번호

---

## 🎯 변경 의도

- `배송지 잘못 입력` 분기의 본질은 “취소 진행”이 아니라 “배송지 수정 반영”이므로, 최종 도착지를 주문 상세로 통일
- 중간 화면(목록/수정/추가)을 거쳐도 원래 맥락을 잃지 않도록 `returnTo`를 일관되게 전달
- 공용 닫기 버튼은 최소 규칙으로 동작하고, 화면별 의도는 호출부에서 명시하도록 책임 분리
- 완료 상태 화면에서는 가능한 액션을 제한해 UX 혼란을 줄임

---

## 🚀 주요 변경 사항

### 1) 주문 취소 → 배송지 변경 플로우 정리
- `배송지 잘못 입력` 선택 시 배송지 목록(`mode=select`)으로 이동
- 배송지 목록 진입 시 `returnTo`를 `/orders/[orderId]`로 설정
- 배송지 단계에서 취소 확인 단계로 회귀하지 않고 주문 상세 반영 흐름으로 연결
- `selectedAddressId`가 존재하면 주소 카드에 선택 주소를 우선 반영

### 2) 주문 상세에서 배송지 반영 처리
- `/orders/[orderId]?selectedAddressId=...` 진입 시 주문 배송지 변경 API 실행
- 반영 후 주문 상세로 재진입하여 최신 배송 정보 확인 가능
- 렌더 단계에서 발생하던 `revalidatePath ... during render` 오류 제거

### 3) 배송지 화면 간 컨텍스트 유지
- 배송지 목록 > 수정 진입 시 현재 목록 URL(+쿼리)을 `returnTo`로 전달
- 배송지 목록 > 추가 진입 시 `mode/returnTo` 컨텍스트 유지
- 배송지 수정/추가 화면의 `X`는 `returnTo` 우선 복귀
- `returnTo`가 없을 경우 안전한 기본 경로로 복귀

### 4) 주문 취소 완료 화면 정리
- 완료 카드에 `hideActions` 옵션 적용
- 완료 상태에서 불필요한 카드 액션(문의/취소/상세) 비노출
- 완료 화면은 결과 확인 + 주문 내역 이동 CTA에 집중

### 5) 공용 Close 버튼 정책 정리
- `href`, `replace`, `fallbackHref` 조합으로 이동 규칙 정리
- `type="button"` 명시로 form 내부 오동작 방지
- 화면별로 닫기 목적지를 명시해 히스토리 의존도를 완화

---

## 🧪 테스트/검증 포인트

### 주문 취소
- `/orders/[orderId]/cancel` 진입
- `배송지 잘못 입력` 선택 후 배송지 목록 이동 확인
- 배송지 선택 후 `선택 완료` 시 주문 상세 이동 확인
- 주문 상세에서 변경된 배송지 노출 확인
- 주문 취소 화면 `X` 클릭 시 back 우선/fallback 동작 확인

### 배송지
- 목록 > 수정 진입 > `X` 복귀 시 목록 컨텍스트 유지 확인
- 목록 > 추가 진입 시 쿼리(`mode`, `returnTo`) 유지 확인
- select 모드에서 선택한 주소가 주문 상세 반영까지 이어지는지 확인

### 완료 화면
- 주문 취소 완료 카드 액션 버튼 비노출 확인
- 하단 CTA로 주문 내역 이동 확인

### 공통
- 닫기 버튼이 form submit을 유발하지 않는지 확인
- 주요 변경 파일 ESLint 통과 확인

---

## ⚠️ 참고 사항

- 이번 변경은 “주문취소-배송지-주문상세” 연계 안정화와 닫기 버튼 정책 정리에 집중했습니다.
- 테스트 페이지(`src/app/test/page.tsx`)는 커밋 대상에서 제외했습니다.
- `next.config.ts` 보정은 별도 `chore` 커밋으로 분리했습니다.

---

## ✅ 체크리스트

- [x] 코드 컨벤션 준수
- [x] 린트 통과
- [x] 주요 사용자 플로우 수동 검증
- [x] 주문취소/배송지/주문상세 연동 동작 확인

---

## 이슈 해결 여부

Closes #이슈번호
