### PR TITLE
[FEAT]: 홈/카테고리 상품 카드 찜하기 기능 확장

### DIFF
--- a/src/components/layout/main-nav-bar.tsx
+++ b/src/components/layout/main-nav-bar.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 
 export default function MainNavBar() {
   return (
-    <div className="font-pretendard sticky bottom-0 flex w-full items-center justify-around border-t border-[#c3c3c3] bg-white py-3 text-sm font-medium">
+    <div className="font-pretendard sticky bottom-0 z-50 flex w-full items-center justify-around border-t border-[#c3c3c3] bg-white py-3 text-sm font-medium">
       <Link href={'/'} className="flex flex-col items-center">
         <img src="/icons/home.svg" alt="홈으로 이동" width={30} height={30} />홈
       </Link>

--- a/src/components/product/product-card.tsx
+++ b/src/components/product/product-card.tsx
@@ -1,13 +1,24 @@
 import Link from 'next/link';
 import { Product } from '@/types/domain/product';
+import { WishlistButton } from './wishlist-button';
+
+type ProductWithWishlist = Product & {
+  isLiked?: boolean;
+  wishlistId?: number;
+};
 
 // 카드 UI 컴포넌트, 클릭 시 상세 페이지로 이동함.
 interface ProductCardProps {
-  product: Product;
+  product: ProductWithWishlist;
   detailFrom?: string;
+  showWishlistButton?: boolean;
 }
 
-export default function ProductCard({ product, detailFrom }: ProductCardProps) {
+export default function ProductCard({
+  product,
+  detailFrom,
+  showWishlistButton = false,
+}: ProductCardProps) {
   const href = detailFrom
     ? `/product/${product.id}?from=${encodeURIComponent(detailFrom)}`
     : `/product/${product.id}`;
@@ -15,13 +26,23 @@ export default function ProductCard({ product, detailFrom }: ProductCardProps) {
   return (
     <Link href={href} className="block">
       <div className="font-pretendard flex w-41 flex-col gap-1">
-        <img
-          src={product.thumbnailImageUrl}
-          alt={product.name}
-          width={164}
-          height={170}
-          className="h-[170px] w-[164px] object-cover"
-        />
+        <div className="relative">
+          <img
+            src={product.thumbnailImageUrl}
+            alt={product.name}
+            width={164}
+            height={170}
+            className="h-[170px] w-[164px] object-cover"
+          />
+          {showWishlistButton && (
+            <WishlistButton
+              productId={product.id}
+              initialIsLiked={product.isLiked || false}
+              initialWishlistId={product.wishlistId}
+              className="absolute top-2 right-2"
+            />
+          )}
+        </div>
         <span className="font-extrabold">{product.brandName}</span>
         <span className="line-clamp-2 h-14 w-full overflow-hidden text-lg font-medium text-ellipsis">
           {product.name}

--- a/src/components/product/product-card.tsx
+++ b/src/components/product/product-card.tsx
@@ -1,11 +1,6 @@
 import Link from 'next/link';
-import { Product } from '@/types/domain/product';
+import { ProductWithWishlist } from '@/types/domain/product';
 import { WishlistButton } from './wishlist-button';
-
-type ProductWithWishlist = Product & {
-  isLiked?: boolean;
-  wishlistId?: number;
-};
 
 // 카드 UI 컴포넌트, 클릭 시 상세 페이지로 이동함.
 interface ProductCardProps {

--- a/src/components/product/product-detail-view.tsx
+++ b/src/components/product/product-detail-view.tsx
@@ -17,6 +17,7 @@ import ProductReviewContent from '@/components/product/review/review-section';
 
 import {
   Product,
+  ProductWithWishlist,
   MaterialDescription,
   ProductOption,
 } from '@/types/domain/product';
@@ -46,16 +47,14 @@ interface ProductDetailProps extends Omit<
   imageUrls?: string[];
 }
 
-interface ProductDetailViewProps {
+type ProductDetailViewProps = {
   product: ProductDetailProps;
   similarProducts: Product[];
   userInfo: UserBodyInfo | null;
   analysisData: SizeAnalysisResult | null;
   productReviewSummary?: ReviewStatsData;
   backHref?: string;
-  isLiked?: boolean;
-  wishlistId?: number;
-}
+} & Pick<ProductWithWishlist, 'isLiked' | 'wishlistId'>;
 
 export default function ProductDetailView({
   product,

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -2,6 +2,7 @@ import { api } from '@/lib/api-client';
 import { ProductSearchResult } from '@/types/domain/product';
 import { ProductSortType } from '@/types/enums';
 import { ProductList } from './product-list';
+import { getMyWishlist } from '@/app/actions/wishlist';
 
 interface ProductListContainerProps {
   params: Promise<{ parentId: string; id: string }>;
@@ -35,22 +36,35 @@ export default async function ProductListContainer({
     throw new Error('Invalid category ID');
   }
 
-  const result = await api.get<ProductSearchResult>('/products', {
-    params: {
-      categoryId: safeCategoryId,
-      sortType: safeSortType,
-      page: safePage,
-      size: 20,
-    },
-  });
+  const [result, wishlistItems] = await Promise.all([
+    api.get<ProductSearchResult>('/products', {
+      params: {
+        categoryId: safeCategoryId,
+        sortType: safeSortType,
+        page: safePage,
+        size: 20,
+      },
+    }),
+    getMyWishlist(),
+  ]);
+
+  const wishlistByProductId = new Map(
+    wishlistItems.map((item) => [item.productId, item.wishlistId]),
+  );
+  const productsWithWishlist = result.products.content.map((product) => ({
+    ...product,
+    isLiked: wishlistByProductId.has(product.id),
+    wishlistId: wishlistByProductId.get(product.id),
+  }));
 
   const totalElements = result.products.totalElements;
 
   return (
     <ProductList
-      products={result.products.content}
+      products={productsWithWishlist}
       totalElements={totalElements}
       productDetailFrom={`/category/${parentId}/${subCategoryId}`}
+      showWishlistButton
     />
   );
 }

--- a/src/components/product/product-list.tsx
+++ b/src/components/product/product-list.tsx
@@ -1,11 +1,5 @@
-import { Product } from '@/types/domain/product';
+import { ProductWithWishlist } from '@/types/domain/product';
 import ProductCard from './product-card';
-
-// 상품 목록 데이터를 받아서 그리드 형태로 보여주는 목록 페이지 컴포넌트
-type ProductWithWishlist = Product & {
-  isLiked?: boolean;
-  wishlistId?: number;
-};
 
 interface ProductListProps {
   products: ProductWithWishlist[];

--- a/src/components/product/product-list.tsx
+++ b/src/components/product/product-list.tsx
@@ -2,18 +2,24 @@ import { Product } from '@/types/domain/product';
 import ProductCard from './product-card';
 
 // 상품 목록 데이터를 받아서 그리드 형태로 보여주는 목록 페이지 컴포넌트
+type ProductWithWishlist = Product & {
+  isLiked?: boolean;
+  wishlistId?: number;
+};
 
 interface ProductListProps {
-  products: Product[];
+  products: ProductWithWishlist[];
   title?: string;
   totalElements?: number;
   productDetailFrom?: string;
+  showWishlistButton?: boolean;
 }
 
 export function ProductList({
   products,
   totalElements,
   productDetailFrom,
+  showWishlistButton = false,
 }: ProductListProps) {
   const count = totalElements ?? products.length;
 
@@ -37,6 +43,7 @@ export function ProductList({
                 key={product.id}
                 product={product}
                 detailFrom={productDetailFrom}
+                showWishlistButton={showWishlistButton}
               />
             ))}
           </div>

--- a/src/components/recommend-brand/recommended-brand-client.tsx
+++ b/src/components/recommend-brand/recommended-brand-client.tsx
@@ -5,18 +5,28 @@ import { BrandWithProducts } from '@/types/domain/brand';
 import RecommendedBrandHeader from './recommended-brand-header';
 import RecommendedBrandGridCard from './recommended-brand-grid-card';
 import { getLocaleFromDocument, t } from '@/lib/i18n';
+import { Product } from '@/types/domain/product';
+
+type BrandProduct = Product & {
+  isLiked?: boolean;
+  wishlistId?: number;
+};
+
+type BrandWithWishlistProducts = Omit<BrandWithProducts, 'products'> & {
+  products: BrandProduct[];
+};
 
 interface RecommendedBrandClientProps {
-  brands: BrandWithProducts[];
+  brands: BrandWithWishlistProducts[];
 }
 
 export default function RecommendedBrandClient({
   brands,
 }: RecommendedBrandClientProps) {
-  if (brands.length === 0) return null;
-
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const locale = getLocaleFromDocument();
+
+  if (brands.length === 0) return null;
 
   const currentBrand = brands[selectedIndex];
   const currentProducts = currentBrand?.products || [];

--- a/src/components/recommend-brand/recommended-brand-client.tsx
+++ b/src/components/recommend-brand/recommended-brand-client.tsx
@@ -5,15 +5,10 @@ import { BrandWithProducts } from '@/types/domain/brand';
 import RecommendedBrandHeader from './recommended-brand-header';
 import RecommendedBrandGridCard from './recommended-brand-grid-card';
 import { getLocaleFromDocument, t } from '@/lib/i18n';
-import { Product } from '@/types/domain/product';
-
-type BrandProduct = Product & {
-  isLiked?: boolean;
-  wishlistId?: number;
-};
+import { ProductWithWishlist } from '@/types/domain/product';
 
 type BrandWithWishlistProducts = Omit<BrandWithProducts, 'products'> & {
-  products: BrandProduct[];
+  products: ProductWithWishlist[];
 };
 
 interface RecommendedBrandClientProps {
@@ -21,9 +16,8 @@ interface RecommendedBrandClientProps {
 }
 
 export default function RecommendedBrandClient({
-  brands: initialBrands,
+  brands,
 }: RecommendedBrandClientProps) {
-  const [brands] = useState(initialBrands);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const locale = getLocaleFromDocument();
 

--- a/src/components/recommend-brand/recommended-brand-client.tsx
+++ b/src/components/recommend-brand/recommended-brand-client.tsx
@@ -21,8 +21,9 @@ interface RecommendedBrandClientProps {
 }
 
 export default function RecommendedBrandClient({
-  brands,
+  brands: initialBrands,
 }: RecommendedBrandClientProps) {
+  const [brands] = useState(initialBrands);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const locale = getLocaleFromDocument();
 

--- a/src/components/recommend-brand/recommended-brand-container.tsx
+++ b/src/components/recommend-brand/recommended-brand-container.tsx
@@ -5,10 +5,7 @@ import { getMyWishlist } from '@/app/actions/wishlist';
 
 export default async function RecommendedBrandContainer() {
   const [brandsResult, wishlistResult] = await Promise.allSettled([
-    api.get<BrandWithProducts[]>('/brands/recommend', {
-      cache: 'force-cache',
-      next: { revalidate: 3600, tags: ['recommended-brands'] },
-    }),
+    api.get<BrandWithProducts[]>('/brands/recommend'),
     getMyWishlist(),
   ]);
 

--- a/src/components/recommend-brand/recommended-brand-container.tsx
+++ b/src/components/recommend-brand/recommended-brand-container.tsx
@@ -5,7 +5,10 @@ import { getMyWishlist } from '@/app/actions/wishlist';
 
 export default async function RecommendedBrandContainer() {
   const [brandsResult, wishlistResult] = await Promise.allSettled([
-    api.get<BrandWithProducts[]>('/brands/recommend'),
+    api.get<BrandWithProducts[]>('/brands/recommend', {
+      cache: 'force-cache',
+      next: { revalidate: 60 },
+    }),
     getMyWishlist(),
   ]);
 

--- a/src/components/recommend-brand/recommended-brand-container.tsx
+++ b/src/components/recommend-brand/recommended-brand-container.tsx
@@ -1,9 +1,33 @@
 import { api } from '@/lib/api-client';
 import { BrandWithProducts } from '@/types/domain/brand';
 import RecommendedBrandClient from './recommended-brand-client';
+import { getMyWishlist } from '@/app/actions/wishlist';
 
 export default async function RecommendedBrandContainer() {
-  const brands = await api.get<BrandWithProducts[]>('/brands/recommend');
+  const [brandsResult, wishlistResult] = await Promise.allSettled([
+    api.get<BrandWithProducts[]>('/brands/recommend', {
+      cache: 'force-cache',
+      next: { revalidate: 3600, tags: ['recommended-brands'] },
+    }),
+    getMyWishlist(),
+  ]);
 
-  return <RecommendedBrandClient brands={brands} />;
+  const brands = brandsResult.status === 'fulfilled' ? brandsResult.value : [];
+  const wishlistItems =
+    wishlistResult.status === 'fulfilled' ? wishlistResult.value : [];
+
+  const wishlistByProductId = new Map(
+    wishlistItems.map((item) => [item.productId, item.wishlistId]),
+  );
+
+  const brandsWithWishlist = brands.map((brand) => ({
+    ...brand,
+    products: brand.products.map((product) => ({
+      ...product,
+      isLiked: wishlistByProductId.has(product.id),
+      wishlistId: wishlistByProductId.get(product.id),
+    })),
+  }));
+
+  return <RecommendedBrandClient brands={brandsWithWishlist} />;
 }

--- a/src/components/recommend-brand/recommended-brand-grid-card.tsx
+++ b/src/components/recommend-brand/recommended-brand-grid-card.tsx
@@ -1,17 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { Product } from '@/types/domain/product';
+import { ProductWithWishlist } from '@/types/domain/product';
 import { WishlistButton } from '../product/wishlist-button';
-
-type BrandProduct = Product & {
-  isLiked?: boolean;
-  wishlistId?: number;
-};
 
 export default function RecommendedBrandGridCard({
   product,
 }: {
-  product: BrandProduct;
+  product: ProductWithWishlist;
 }) {
   const href = `/product/${product.id}?from=${encodeURIComponent('/')}`;
 

--- a/src/components/recommend-brand/recommended-brand-grid-card.tsx
+++ b/src/components/recommend-brand/recommended-brand-grid-card.tsx
@@ -1,24 +1,38 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { Product } from '@/types/domain/product';
+import { WishlistButton } from '../product/wishlist-button';
+
+type BrandProduct = Product & {
+  isLiked?: boolean;
+  wishlistId?: number;
+};
 
 export default function RecommendedBrandGridCard({
   product,
 }: {
-  product: Product;
+  product: BrandProduct;
 }) {
   const href = `/product/${product.id}?from=${encodeURIComponent('/')}`;
 
   return (
     <Link href={href} className="block">
       <div className="font-pretendard flex w-41 flex-col gap-1">
-        <Image
-          src={product.thumbnailImageUrl}
-          alt={product.name}
-          width={164}
-          height={170}
-          className="h-[170px] w-[164px] object-cover"
-        />
+        <div className="relative">
+          <Image
+            src={product.thumbnailImageUrl}
+            alt={product.name}
+            width={164}
+            height={170}
+            className="h-[170px] w-[164px] object-cover"
+          />
+          <WishlistButton
+            productId={product.id}
+            initialIsLiked={product.isLiked || false}
+            initialWishlistId={product.wishlistId}
+            className="absolute top-2 right-2"
+          />
+        </div>
         <span className="font-extrabold">{product.brandName}</span>
         <span className="line-clamp-2 h-14 w-full overflow-hidden text-lg font-medium text-ellipsis">
           {product.name}

--- a/src/components/recommend-carousel/recommend-product-container.tsx
+++ b/src/components/recommend-carousel/recommend-product-container.tsx
@@ -3,6 +3,7 @@ import { Product } from '@/types/domain/product';
 import RecommendedProductCard from './recommended-product-card';
 import { RecommendCarouselItem } from './recommend-carousel-item';
 import { RecommendCarousel } from './recommend-carousel';
+import { getMyWishlist } from '@/app/actions/wishlist';
 
 interface RecommendProductContainerProps {
   endpoint: string;
@@ -13,12 +14,31 @@ export default async function RecommendProductContainer({
   endpoint,
   heading,
 }: RecommendProductContainerProps) {
-  const products = await api.get<Product[]>(endpoint);
+  const [productsResult, wishlistResult] = await Promise.allSettled([
+    api.get<Product[]>(endpoint),
+    getMyWishlist(),
+  ]);
+
+  const products =
+    productsResult.status === 'fulfilled' ? productsResult.value : [];
+  const wishlistItems =
+    wishlistResult.status === 'fulfilled' ? wishlistResult.value : [];
+
+  const wishlistByProductId = new Map(
+    wishlistItems.map((item) => [item.productId, item.wishlistId]),
+  );
+
   return (
     <RecommendCarousel heading={heading}>
       {products.map((product) => (
         <RecommendCarouselItem key={product.id}>
-          <RecommendedProductCard productInfo={product} />
+          <RecommendedProductCard
+            productInfo={{
+              ...product,
+              isLiked: wishlistByProductId.has(product.id),
+              wishlistId: wishlistByProductId.get(product.id),
+            }}
+          />
         </RecommendCarouselItem>
       ))}
     </RecommendCarousel>

--- a/src/components/recommend-carousel/recommended-product-card.tsx
+++ b/src/components/recommend-carousel/recommended-product-card.tsx
@@ -1,17 +1,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { Product } from '@/types/domain/product';
+import { ProductWithWishlist } from '@/types/domain/product';
 import { WishlistButton } from '../product/wishlist-button';
-
-interface RecommendedProduct extends Product {
-  isLiked?: boolean;
-  wishlistId?: number;
-}
 
 export default function RecommendedProductCard({
   productInfo,
 }: {
-  productInfo: RecommendedProduct;
+  productInfo: ProductWithWishlist;
 }) {
   const href = `/product/${productInfo.id}?from=${encodeURIComponent('/')}`;
   const hasDiscount = productInfo.discountRate && productInfo.discountRate > 0;

--- a/src/components/recommend-carousel/recommended-product-card.tsx
+++ b/src/components/recommend-carousel/recommended-product-card.tsx
@@ -5,6 +5,7 @@ import { WishlistButton } from '../product/wishlist-button';
 
 interface RecommendedProduct extends Product {
   isLiked?: boolean;
+  wishlistId?: number;
 }
 
 export default function RecommendedProductCard({
@@ -72,6 +73,7 @@ export default function RecommendedProductCard({
           <WishlistButton
             productId={productInfo.id}
             initialIsLiked={productInfo.isLiked || false}
+            initialWishlistId={productInfo.wishlistId}
             className="absolute top-2 right-2"
           />
         </div>

--- a/src/types/domain/product.ts
+++ b/src/types/domain/product.ts
@@ -16,6 +16,11 @@ export interface Product {
   reviewRating: number;
 }
 
+export type ProductWithWishlist = Product & {
+  isLiked?: boolean;
+  wishlistId?: number;
+};
+
 export interface MaterialDescription {
   advantages: string[];
   disadvantages: string[];


### PR DESCRIPTION
## 📝 개요
홈 추천(상품/브랜드)과 하위 카테고리 상품 카드에 `찜하기` 버튼 및 연동 로직을 추가한 작업입니다.

기존에는 일부 카드에서만 찜하기가 가능했고, 홈/카테고리 목록에서는 동일한 사용자 행동을 제공하지 못했습니다.  
이번 PR은 **카드 단위 찜 경험 확장 + 초기 찜 상태 일치 + 기존 흐름(상세/찜목록)과의 일관성 유지**를 목표로 반영했습니다.

관련 이슈 번호: #이슈번호

Closes #이슈번호

## 🎯 변경 의도
- 홈/카테고리 목록에서도 상세와 동일한 찜 액션 제공
- 카드 최초 렌더 시 실제 찜 상태(`isLiked`, `wishlistId`)를 반영해 UI 신뢰도 확보
- 공통 찜 버튼(`WishlistButton`, `useWishlist`) 재사용으로 유지보수성 확보
- 페이지별 적용 범위 제어로 사이드이펙트 최소화

## 🚀 주요 변경 사항
### 1) 홈 추천 상품 카드 찜 연동
- 추천 상품 조회 시 내 찜 목록을 함께 조회
- 상품별 `isLiked`, `wishlistId` 매핑 후 카드에 전달
- 카드에서 `WishlistButton`에 초기 상태값 주입

### 2) 랜덤 브랜드 추천 카드 찜 연동
- 브랜드 추천 데이터에도 찜 상태 매핑 적용
- 브랜드 상품 그리드 카드 우상단에 `WishlistButton` 추가
- 클라이언트 타입 보강(브랜드 상품 + 찜 상태 필드)

### 3) 하위 카테고리 상품 카드 찜 연동
- 하위 카테고리 상품 목록 조회 시 찜 목록 병렬 조회
- `ProductListContainer`에서 상품별 찜 상태 매핑
- `ProductList`에 `showWishlistButton` 옵션 추가
- `ProductCard`에서 옵션 활성 시 찜 버튼 렌더링

### 4) 구조/안정성 보완
- 브랜드 추천 클라이언트 컴포넌트의 Hook 호출 순서 정리(lint 규칙 대응)
- 기존 상세/찜목록에서 사용하던 찜 토글 훅 로직 재사용

## 🧪 테스트/검증 포인트
### 홈
- 추천 상품 카드에서 찜/해제 동작 확인
- 랜덤 브랜드 추천 카드에서 찜/해제 동작 확인
- 카드 클릭(상세 이동)과 찜 버튼 클릭 이벤트 충돌 없는지 확인

### 하위 카테고리
- 상품 카드에 찜 버튼 노출 확인
- 찜/해제 후 아이콘 상태 즉시 반영(optimistic) 확인
- 정렬/페이지 변경 시 초기 찜 상태가 실제 데이터와 일치하는지 확인

### 공통
- 비로그인/세션 만료 상황에서 오류 처리(실패 시 롤백) 확인
- eslint 대상 파일 검사 통과 확인

## ✅ 체크리스트
- [x] 코드 컨벤션 준수
- [x] 기능 단위 커밋 분리
- [x] 린트 최종 확인
- [x] 주요 사용자 플로우 수동 점검 (홈 추천/브랜드 추천/하위 카테고리 찜 버튼)