### PR TITLE
[REFACTOR]: 리뷰 탭 소재 텍스트 줄바꿈 및 이미지 캐러셀 UI 보정

### DIFF
--- a/src/components/product/review/ai-material-carousel.tsx
+++ b/src/components/product/review/ai-material-carousel.tsx
@@ -58,7 +58,7 @@ export default function AiMaterialCarousel({
   ];
 
   return (
-    <div className="w-full px-4">
+    <div className="w-full">
       <div className="mb-10 flex items-center gap-2">
         <h3 className="text-2xl leading-5 font-medium -tracking-[0.08px] not-italic">
           {materialName}

--- a/src/components/product/review/review-image-modal.tsx
+++ b/src/components/product/review/review-image-modal.tsx
@@ -8,8 +8,6 @@ import {
   Carousel,
   CarouselContent,
   CarouselItem,
-  CarouselNext,
-  CarouselPrevious,
   type CarouselApi,
 } from '@/components/ui/carousel';
 
@@ -78,11 +76,11 @@ export default function ReviewImageModal({
             className="grid h-full w-full space-x-2 py-0"
             opts={{ startIndex: initialSlide, loop: true }}
           >
-            <CarouselContent className="m-0 flex h-full">
+            <CarouselContent className="flex h-full">
               {imageUrls.map((src, index) => (
                 <CarouselItem
                   key={index}
-                  className="flex h-full basis-full items-center justify-center gap-2 p-0 pl-0"
+                  className="flex h-full basis-full items-center justify-center p-0 pl-4"
                 >
                   <div className="relative h-full min-h-0 w-full">
                     <Image
@@ -97,12 +95,6 @@ export default function ReviewImageModal({
                 </CarouselItem>
               ))}
             </CarouselContent>
-            {imageUrls.length > 1 && (
-              <>
-                <CarouselPrevious className="left-4 z-[100] h-12 w-12 border-none bg-white/10 text-white hover:bg-white/30 [&_svg]:h-8 [&_svg]:w-8" />
-                <CarouselNext className="right-4 z-[100] h-12 w-12 border-none bg-white/10 text-white hover:bg-white/30 [&_svg]:h-8 [&_svg]:w-8" />
-              </>
-            )}
           </Carousel>
         </div>
       </DialogContent>

--- a/src/components/product/review/review-item.tsx
+++ b/src/components/product/review/review-item.tsx
@@ -173,9 +173,9 @@ export default function ReviewItem({
           }}
           className="mb-4 w-full"
         >
-          <CarouselContent className="-ml-8">
+          <CarouselContent>
             {review.reviewImageUrls.map((src, index) => (
-              <CarouselItem key={index} className="basis-1/3">
+              <CarouselItem key={index} className="basis-auto">
                 <div
                   className="relative h-[120px] w-[120px] flex-shrink-0 cursor-pointer overflow-hidden rounded-lg bg-gray-50 transition-transform active:scale-95"
                   onClick={() => handleImageClick(index)}


### PR DESCRIPTION
## 📝 개요

- 리뷰 탭에서 발생하던 UI 깨짐(소재 정보 줄바꿈, 리뷰 카드 이미지 캐러셀 잘림, 이미지 모달 화살표 노출)을 수정했습니다.
- 관련 이슈 번호: #이슈번호

## 🚀 주요 변경 사항

- [x] 리뷰 카드 캐러셀 레이아웃 보정
- `src/components/product/review/review-item.tsx`
- `CarouselContent`의 과도한 음수 마진 제거
- 썸네일 아이템을 `basis-auto`로 변경해 잘림 현상 해소

- [x] 이미지 모달 캐러셀 UI 정리
- `src/components/product/review/review-image-modal.tsx`
- 좌/우 화살표 버튼 제거
- 모달 캐러셀 아이템 간 간격(`pl-4`) 적용

- [x] 리뷰 탭 소재 정보 표시 보정
- `src/components/product/review/ai-material-carousel.tsx`
- 상단 소재명 영역 여백 정리(`w-full`)
- (소재명 줄바꿈 깨짐 이슈 대응)

## 📸 스크린샷 (선택)

|       기능 구현 화면       |
| :------------------------: |
| 사진을 여기에 드래그하세요 |

## ✅ 체크리스트

- [x] 빌드 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 console.log는 제거했나요?

## 이슈 해결 여부

Closes #이슈번호
