### PR TITLE
[FEAT]: 카테고리 페이지 구조 개편 및 개인화 추천 섹션 추가

### DIFF
--- a/src/app/actions/category.ts
+++ b/src/app/actions/category.ts
@@ -1,0 +1,50 @@
+'use server';
+
+import { api } from '@/lib/api-client';
+import { rethrowNextError } from '@/lib/server-action-utils';
+import type {
+  Category,
+  CategorySimple,
+  SubCategory,
+} from '@/types/domain/category';
+
+/** 전체 카테고리 조회 */
+export async function getCategories(): Promise<Category[]> {
+  try {
+    return await api.get<Category[]>('/categories');
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('카테고리 조회 실패:', error);
+    return [];
+  }
+}
+
+/** 특정 상위 카테고리의 하위 카테고리 조회 */
+export async function getSubCategories(
+  categoryId: number,
+): Promise<SubCategory[]> {
+  try {
+    return await api.get<SubCategory[]>(
+      `/categories/${categoryId}/sub-categories`,
+    );
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('하위 카테고리 조회 실패:', { error, categoryId });
+    return [];
+  }
+}
+
+/** 추천 하위 카테고리 조회 */
+export async function getRecommendedSubCategories(
+  count = 8,
+): Promise<CategorySimple[]> {
+  try {
+    return await api.get<CategorySimple[]>('/categories/recommended-sub', {
+      params: { count },
+    });
+  } catch (error) {
+    rethrowNextError(error);
+    console.error('추천 하위 카테고리 조회 실패:', { error, count });
+    return [];
+  }
+}

--- a/src/app/category/[parentId]/[id]/layout.tsx
+++ b/src/app/category/[parentId]/[id]/layout.tsx
@@ -1,0 +1,23 @@
+import SubCategorySliderContainer from '@/components/sub-category-slider/sub-category-slider-container';
+import CategoryParentHeaderBar from '@/components/category/category-parent-header-bar';
+import { Suspense } from 'react';
+
+export default async function CategoryProductLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ parentId: string }>;
+}) {
+  return (
+    <section className="flex h-full min-h-0 flex-col">
+      <CategoryParentHeaderBar />
+
+      <Suspense>
+        <SubCategorySliderContainer params={params} />
+      </Suspense>
+
+      <main className="min-h-0 flex-1">{children}</main>
+    </section>
+  );
+}

--- a/src/app/category/[parentId]/[id]/layout.tsx
+++ b/src/app/category/[parentId]/[id]/layout.tsx
@@ -13,7 +13,7 @@ export default async function CategoryProductLayout({
     <section className="flex h-full min-h-0 flex-col">
       <CategoryParentHeaderBar />
 
-      <Suspense>
+      <Suspense fallback={<div className="h-12 animate-pulse bg-gray-100" />}>
         <SubCategorySliderContainer params={params} />
       </Suspense>
 

--- a/src/app/category/[parentId]/layout.tsx
+++ b/src/app/category/[parentId]/layout.tsx
@@ -1,25 +1,7 @@
-// app/category/[parentId]/layout.tsx
-
-import SubCategorySliderContainer from '@/components/sub-category-slider/sub-category-slider-container';
-import CategoryParentHeaderBar from '@/components/category/category-parent-header-bar';
-import { Suspense } from 'react';
-
-export default async function CategoryLayout({
+export default function CategoryParentLayout({
   children,
-  params,
 }: {
   children: React.ReactNode;
-  params: Promise<{ parentId: string }>;
 }) {
-  return (
-    <section className="flex flex-col">
-      <CategoryParentHeaderBar />
-
-      <Suspense>
-        <SubCategorySliderContainer params={params} />
-      </Suspense>
-
-      <main>{children}</main>
-    </section>
-  );
+  return <>{children}</>;
 }

--- a/src/app/category/[parentId]/page.tsx
+++ b/src/app/category/[parentId]/page.tsx
@@ -1,0 +1,38 @@
+import { getCategories } from '@/app/actions/category';
+import CategoryContentList from '@/components/category/category-content-list';
+import CategoryLayout from '@/components/category/category-layout';
+import { redirect } from 'next/navigation';
+
+interface PageProps {
+  params: Promise<{ parentId: string }>;
+}
+
+export default async function CategoryParentPage({ params }: PageProps) {
+  const { parentId } = await params;
+  const categories = await getCategories();
+  const sortedCategories = categories.toSorted(
+    (a, b) => a.displayOrder - b.displayOrder,
+  );
+
+  if (sortedCategories.length === 0) {
+    redirect('/category');
+  }
+
+  const parsedParentId = Number(parentId);
+  const hasMatchedParent = sortedCategories.some(
+    (category) => category.categoryId === parsedParentId,
+  );
+
+  if (!Number.isFinite(parsedParentId) || !hasMatchedParent) {
+    redirect(`/category/${sortedCategories[0].categoryId}`);
+  }
+
+  return (
+    <CategoryLayout
+      categories={sortedCategories}
+      initialCategoryId={parsedParentId}
+    >
+      <CategoryContentList categories={sortedCategories} />
+    </CategoryLayout>
+  );
+}

--- a/src/components/category/category-layout.tsx
+++ b/src/components/category/category-layout.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import Link from 'next/link';
-import Image from 'next/image';
-import SearchBar from '@/components/search-bar/search-bar';
 import useScrollSpy from './use-scroll-spy';
 import CategoryTab from './category-tab';
 import { Category } from '@/types/domain/category';
+import CategoryParentHeaderBar from './category-parent-header-bar';
 
 interface CategoryLayoutProps {
   children: React.ReactNode;
   categories: Category[];
+  initialCategoryId?: number;
 }
 
 // 사용자의 스크롤 위치에 따라 사이드바의 활성 탭을 자동으로 변경하고(Scroll Spy), 탭을 클릭하면 해당 콘텐츠 위치로 이동.
@@ -18,11 +17,13 @@ interface CategoryLayoutProps {
 export default function CategoryLayout({
   children,
   categories,
+  initialCategoryId,
 }: CategoryLayoutProps) {
   const categoryIds = categories.map((c) => c.categoryId.toString());
 
   const { activeId, scrollToId, containerRef } = useScrollSpy(categoryIds);
   const sidebarRef = useRef<HTMLUListElement>(null);
+  const hasSyncedInitialRef = useRef(false);
 
   useEffect(() => {
     if (!activeId) return;
@@ -33,18 +34,23 @@ export default function CategoryLayout({
     });
   }, [activeId]);
 
+  useEffect(() => {
+    if (hasSyncedInitialRef.current) return;
+    if (!initialCategoryId) return;
+    const targetId = initialCategoryId.toString();
+    if (!categoryIds.includes(targetId)) return;
+
+    hasSyncedInitialRef.current = true;
+    const timer = setTimeout(() => {
+      scrollToId(targetId);
+    }, 0);
+
+    return () => clearTimeout(timer);
+  }, [initialCategoryId, categoryIds, scrollToId]);
+
   return (
     <div className="flex h-screen w-full flex-col bg-white">
-      <header className="z-20 flex shrink-0 items-center gap-3 border-b bg-white px-4 py-3">
-        <Link
-          href="/"
-          className="-ml-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full hover:bg-gray-100"
-          aria-label="홈으로 돌아가기"
-        >
-          <Image src="/icons/arrow.svg" width={24} height={24} alt="" />
-        </Link>
-        <SearchBar />
-      </header>
+      <CategoryParentHeaderBar />
 
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <nav className="scrollbar-hide z-10 flex h-full min-h-0 w-32 shrink-0 flex-col overflow-y-auto border-r border-gray-300 bg-gray-100 pb-20">

--- a/src/components/category/category-main-header.tsx
+++ b/src/components/category/category-main-header.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import SearchBar from '@/components/search-bar/search-bar';
+
+export default function CategoryMainHeader() {
+  return (
+    <header className="sticky top-0 z-40 border-b border-gray-200 bg-white">
+      <div className="px-4 py-8">
+        <h1 className="mb-10 text-center text-3xl font-bold text-black">
+          카테고리
+        </h1>
+        <SearchBar />
+      </div>
+    </header>
+  );
+}

--- a/src/components/category/category-main-layout.tsx
+++ b/src/components/category/category-main-layout.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { Category, CategorySimple } from '@/types/domain/category';
+import MainNavBar from '@/components/layout/main-nav-bar';
+import CategoryMainHeader from './category-main-header';
+import CategoryMainRecommend from './category-main-recommend';
+import CategoryMainParentList from './category-main-parent-list';
+import useHideOnScroll from './use-hide-on-scroll';
+
+interface CategoryMainLayoutProps {
+  categories: Category[];
+  recommended: CategorySimple[];
+  parentLookup: Record<number, number>;
+  userName: string;
+}
+
+export default function CategoryMainLayout({
+  categories,
+  recommended,
+  parentLookup,
+  userName,
+}: CategoryMainLayoutProps) {
+  const isRecommendVisible = useHideOnScroll({
+    topOffset: 24,
+    scrollDelta: 12,
+  });
+
+  return (
+    <main className="min-h-screen bg-white pb-96">
+      <CategoryMainHeader />
+
+      <CategoryMainRecommend
+        items={recommended}
+        parentLookup={parentLookup}
+        isVisible={isRecommendVisible}
+        userName={userName}
+      />
+
+      <CategoryMainParentList categories={categories} />
+
+      <div className="fixed bottom-0 w-full">
+        <MainNavBar />
+      </div>
+    </main>
+  );
+}

--- a/src/components/category/category-main-layout.tsx
+++ b/src/components/category/category-main-layout.tsx
@@ -38,9 +38,7 @@ export default function CategoryMainLayout({
 
       <CategoryMainParentList categories={categories} />
 
-      <div className="fixed bottom-0 w-full">
-        <MainNavBar />
-      </div>
+      <MainNavBar />
     </main>
   );
 }

--- a/src/components/category/category-main-parent-list.tsx
+++ b/src/components/category/category-main-parent-list.tsx
@@ -1,0 +1,32 @@
+import type { Category } from '@/types/domain/category';
+import { ChevronRight } from 'lucide-react';
+import Link from 'next/link';
+
+interface CategoryMainParentListProps {
+  categories: Category[];
+}
+
+export default function CategoryMainParentList({
+  categories,
+}: CategoryMainParentListProps) {
+  return (
+    <ul className="mt-12 bg-white">
+      {categories.map((category) => (
+        <li
+          key={category.categoryId}
+          className="border-b border-black last:border-b-0"
+        >
+          <Link
+            href={`/category/${category.categoryId}`}
+            className="flex items-center justify-between p-6"
+          >
+            <span className="text-2xl leading-6 font-bold -tracking-[0.408px] text-black">
+              {category.name}
+            </span>
+            <ChevronRight size={44} className="text-black" />
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/category/category-main-recommend.tsx
+++ b/src/components/category/category-main-recommend.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import type { CategorySimple } from '@/types/domain/category';
+import Image from 'next/image';
+import Link from 'next/link';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  type CarouselApi,
+} from '../ui/carousel';
+import { useCarouselDots } from '../banner-carousel/use-carousel-dots';
+import { DotNavigation } from '../banner-carousel/dot-navigation';
+
+interface CategoryMainRecommendProps {
+  items: CategorySimple[];
+  parentLookup: Record<number, number>;
+  isVisible: boolean;
+  userName: string;
+}
+
+export default function CategoryMainRecommend({
+  items,
+  parentLookup,
+  isVisible,
+  userName,
+}: CategoryMainRecommendProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const { current, count, scrollTo } = useCarouselDots(api);
+
+  return (
+    <section
+      className={`overflow-hidden border-b border-gray-200 bg-white transition-all duration-300 ${
+        isVisible ? 'max-h-[280px] opacity-100' : 'max-h-0 opacity-0'
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <div className="px-4 py-5">
+        <h2 className="mb-4 text-2xl leading-normal font-bold">
+          {userName}님을 위한 추천
+        </h2>
+
+        <Carousel
+          setApi={setApi}
+          opts={{ align: 'start', containScroll: 'trimSnaps' }}
+          className="w-full"
+        >
+          <CarouselContent className="-ml-4 pb-1">
+            {items.map((item) => {
+              const parentId = parentLookup[item.categoryId];
+              const href = parentId
+                ? `/category/${parentId}/${item.categoryId}`
+                : '/category';
+
+              return (
+                <CarouselItem key={item.categoryId} className="basis-auto pl-4">
+                  <Link
+                    href={href}
+                    className="flex flex-col items-center gap-2"
+                  >
+                    <div className="relative h-[96px] w-[96px] overflow-hidden rounded-md bg-gray-100">
+                      <Image
+                        src={item.iconUrl || '/icons/star.svg'}
+                        alt={item.name}
+                        fill
+                        sizes="96px"
+                        className="object-cover"
+                      />
+                    </div>
+                    <span className="w-full text-center text-xl leading-normal font-semibold">
+                      {item.name}
+                    </span>
+                  </Link>
+                </CarouselItem>
+              );
+            })}
+          </CarouselContent>
+        </Carousel>
+
+        <DotNavigation
+          count={count}
+          current={current}
+          onDotClick={scrollTo}
+          className="pt-3 pb-0"
+        />
+      </div>
+    </section>
+  );
+}

--- a/src/components/category/category-parent-header-bar.tsx
+++ b/src/components/category/category-parent-header-bar.tsx
@@ -6,15 +6,24 @@ import SearchBar from '@/components/search-bar/search-bar';
 
 export default function CategoryParentHeaderBar() {
   return (
-    <header className="sticky top-0 z-[60] flex h-[85px] shrink-0 items-center gap-3 border-b bg-white px-4 py-5">
-      <Link
-        href="/category"
-        className="-ml-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full hover:bg-gray-100"
-        aria-label="카테고리 목록으로 돌아가기"
-      >
-        <Image src="/icons/arrow.svg" width={24} height={24} alt="" />
-      </Link>
-      <SearchBar />
+    <header className="sticky top-0 z-[60] border-b border-gray-200 bg-white">
+      <div className="px-4 pt-6 pb-4">
+        <div className="relative mb-4 flex items-center justify-center">
+          <Link
+            href="/category"
+            className="absolute left-0 -ml-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-full hover:bg-gray-100"
+            aria-label="카테고리 목록으로 돌아가기"
+          >
+            <Image src="/icons/arrow.svg" width={24} height={24} alt="" />
+          </Link>
+          <h1 className="text-center text-3xl font-bold text-black">
+            카테고리
+          </h1>
+        </div>
+        <div className="min-w-0">
+          <SearchBar />
+        </div>
+      </div>
     </header>
   );
 }

--- a/src/components/category/use-hide-on-scroll.ts
+++ b/src/components/category/use-hide-on-scroll.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface UseHideOnScrollOptions {
+  topOffset?: number;
+  scrollDelta?: number;
+  initialVisible?: boolean;
+}
+
+export default function useHideOnScroll(options: UseHideOnScrollOptions = {}) {
+  const { topOffset = 24, scrollDelta = 10, initialVisible = true } = options;
+
+  const [isVisible, setIsVisible] = useState(initialVisible);
+  const lastScrollYRef = useRef(0);
+  const isVisibleRef = useRef(initialVisible);
+  const tickingRef = useRef(false);
+  const rafIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    isVisibleRef.current = isVisible;
+  }, [isVisible]);
+
+  useEffect(() => {
+    lastScrollYRef.current = window.scrollY;
+
+    const updateVisibility = () => {
+      tickingRef.current = false;
+      const currentY = Math.max(window.scrollY, 0);
+      const diff = currentY - lastScrollYRef.current;
+
+      if (currentY <= topOffset) {
+        if (!isVisibleRef.current) {
+          isVisibleRef.current = true;
+          setIsVisible(true);
+        }
+        lastScrollYRef.current = currentY;
+        return;
+      }
+
+      if (Math.abs(diff) < scrollDelta) return;
+
+      const nextVisible = diff < 0;
+      if (nextVisible !== isVisibleRef.current) {
+        isVisibleRef.current = nextVisible;
+        setIsVisible(nextVisible);
+      }
+
+      lastScrollYRef.current = currentY;
+    };
+
+    const handleScroll = () => {
+      if (tickingRef.current) return;
+      tickingRef.current = true;
+      rafIdRef.current = window.requestAnimationFrame(updateVisibility);
+    };
+
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      if (rafIdRef.current !== null) {
+        window.cancelAnimationFrame(rafIdRef.current);
+      }
+    };
+  }, [topOffset, scrollDelta]);
+
+  return isVisible;
+}

--- a/src/components/product/product-header.tsx
+++ b/src/components/product/product-header.tsx
@@ -18,11 +18,8 @@ interface ProductHeaderProps {
  * @param {number} props.initialCartCount - 초기 장바구니 담긴 개수 (SSR)
  * @returns {JSX.Element} 상품 헤더 컴포넌트
  */
-export default function ProductHeader({
-  categoryID,
-  backHref,
-}: ProductHeaderProps) {
-  const fallback = categoryID ? `/category/${categoryID}` : '/category';
+export default function ProductHeader({ backHref }: ProductHeaderProps) {
+  const fallback = '/category';
 
   return (
     <header className="sticky top-0 z-50 flex h-[90px] w-full items-center justify-between bg-white px-[18px]">

--- a/src/components/recommend-carousel/recommend-carousel.tsx
+++ b/src/components/recommend-carousel/recommend-carousel.tsx
@@ -1,19 +1,30 @@
-import { Carousel, CarouselContent } from '../ui/carousel';
+'use client';
+
+import { useState } from 'react';
+import { Carousel, CarouselContent, type CarouselApi } from '../ui/carousel';
+import { useCarouselDots } from '@/components/banner-carousel/use-carousel-dots';
+import { DotNavigation } from '@/components/banner-carousel/dot-navigation';
 
 interface RecommendCarouselProps {
   heading: string;
   children: React.ReactNode;
+  showDots?: boolean;
 }
 
 export function RecommendCarousel({
   heading,
   children,
+  showDots = false,
 }: RecommendCarouselProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const { current, count, scrollTo } = useCarouselDots(api);
+
   return (
     <div className="flex w-full flex-col items-center gap-7.5 px-4">
       <h2 className="font-pretendard text-2xl font-bold">{heading}</h2>
 
       <Carousel
+        setApi={setApi}
         opts={{
           align: 'start',
           dragFree: true,
@@ -23,6 +34,14 @@ export function RecommendCarousel({
       >
         <CarouselContent className="-ml-4">{children}</CarouselContent>
       </Carousel>
+      {showDots && (
+        <DotNavigation
+          count={count}
+          current={current}
+          onDotClick={scrollTo}
+          className="pt-1 pb-0"
+        />
+      )}
     </div>
   );
 }

--- a/src/components/recommend-carousel/recommend-category-container.tsx
+++ b/src/components/recommend-carousel/recommend-category-container.tsx
@@ -37,7 +37,6 @@ export default async function RecommendCategoryContainer() {
 
   return (
     <div className="w-full overflow-hidden">
-      <h2>추천 카테고리</h2>
       <RecommendCarousel heading="추천 카테고리" showDots={true}>
         {categories.map((category) => (
           <RecommendCarouselItem key={category.categoryId}>

--- a/src/components/recommend-carousel/recommend-category-container.tsx
+++ b/src/components/recommend-carousel/recommend-category-container.tsx
@@ -1,5 +1,7 @@
-import { api } from '@/lib/api-client';
-import { Category, SubCategory } from '@/types/domain/category';
+import {
+  getCategories,
+  getRecommendedSubCategories,
+} from '@/app/actions/category';
 import { RecommendCarousel } from './recommend-carousel';
 import { RecommendCarouselItem } from './recommend-carousel-item';
 import RecommendedCategoryCard from './recommended-category-card';
@@ -11,8 +13,8 @@ export default async function RecommendCategoryContainer() {
     return null;
   }
   const [recommendedSubResult, allCategoriesResult] = await Promise.allSettled([
-    api.get<SubCategory[]>('/categories/recommended-sub'),
-    api.get<Category[]>('/categories'),
+    getRecommendedSubCategories(),
+    getCategories(),
   ]);
 
   if (recommendedSubResult.status !== 'fulfilled') {
@@ -36,7 +38,7 @@ export default async function RecommendCategoryContainer() {
   return (
     <div className="w-full overflow-hidden">
       <h2>추천 카테고리</h2>
-      <RecommendCarousel heading="추천 카테고리">
+      <RecommendCarousel heading="추천 카테고리" showDots={true}>
         {categories.map((category) => (
           <RecommendCarouselItem key={category.categoryId}>
             <RecommendedCategoryCard

--- a/src/components/recommend-carousel/recommended-category-card.tsx
+++ b/src/components/recommend-carousel/recommended-category-card.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link';
-import { SubCategory } from '@/types/domain/category';
+import Image from 'next/image';
+import { CategorySimple } from '@/types/domain/category';
 
 interface CategoryCarouselCardProps {
-  category: SubCategory;
+  category: CategorySimple;
   parentCategoryId: number | null;
 }
 
@@ -17,7 +18,7 @@ export default function RecommendedCategoryCard({
   let categorySquare;
   if (category.iconUrl) {
     categorySquare = (
-      <img
+      <Image
         src={category.iconUrl}
         alt={category.name}
         width={200}

--- a/src/components/sub-category-slider/sub-category-slider-container.tsx
+++ b/src/components/sub-category-slider/sub-category-slider-container.tsx
@@ -1,5 +1,4 @@
-import { api } from '@/lib/api-client';
-import { SubCategory } from '@/types/domain/category';
+import { getSubCategories } from '@/app/actions/category';
 import SubCategorySlider from './sub-category-slider';
 
 interface Props {
@@ -8,10 +7,11 @@ interface Props {
 
 export default async function SubCategorySliderContainer({ params }: Props) {
   const { parentId } = await params;
+  const parsedParentId = Number(parentId);
 
-  const subCategories = await api.get<SubCategory[]>(
-    `/categories/${parentId}/sub-categories`,
-  );
+  const subCategories = Number.isFinite(parsedParentId)
+    ? await getSubCategories(parsedParentId)
+    : [];
 
   const parentCategoryName = subCategories[0]?.parentCategoryName ?? '';
 


### PR DESCRIPTION
## 📝 개요
카테고리 페이지 전반의 데이터 로딩/라우팅 구조를 정리하고, 메인 카테고리 화면에 개인화 추천 UX를 추가한 PR입니다.

기존에는 카테고리 관련 API 호출이 여러 컴포넌트에 분산되어 있어 유지보수 포인트가 늘어났고, `/category`와 하위 라우트(`/category/[parentId]`, `/category/[parentId]/[id]`)의 역할이 명확히 분리되지 않아 초기 진입/이동 흐름이 일관되지 않은 문제가 있었습니다.

이번 PR은 **Server Action 기반 호출 통합 + 라우트 책임 분리 + 메인 카테고리 탐색 경험 개선**을 핵심 목표로 반영했습니다.

관련 이슈 번호: #이슈번호  
Closes #이슈번호

## 📌 배경 및 문제점
- 카테고리 데이터 호출이 화면 단위로 분산되어 중복 로직이 발생
- parent/product 라우트 경계가 느슨하여 진입 시 초기 상태 동기화가 불안정
- 카테고리 메인(`/category`)이 단순 리스트 중심이라 탐색 진입 경험이 약함
- 카테고리 헤더/상품 헤더의 일부 UI 동작이 케이스별로 일관되지 않음

## 🎯 변경 의도
- 카테고리 도메인의 데이터 접근 지점을 `src/app/actions/category.ts`로 통합
- 메인/parent/product 라우트의 책임을 명확히 분리
- 메인 화면에 개인화 추천을 배치해 첫 진입 탐색 효율 개선
- 스크롤 상호작용 및 fallback 경로를 정리해 예외 케이스 단순화

## 🧩 변경 범위
### 포함
- 카테고리 Server Action 신규 추가 및 호출처 치환
- 카테고리 메인 전용 레이아웃/컴포넌트 신설
- parent/product 라우트 레이아웃 분리
- 카테고리 상단 헤더 UI 개선
- 상품 헤더 뒤로가기 fallback 경로 보정

## 🚀 주요 변경 사항
### 1) 카테고리 데이터 로딩 구조 통합 (Server Action)
- 파일: `src/app/actions/category.ts`
- 추가 함수:
  - `getCategories()`
  - `getSubCategories(categoryId: number)`
  - `getRecommendedSubCategories(count = 8)`
- 에러 처리:
  - `rethrowNextError` 사용
  - 로깅 후 안전한 기본값(빈 배열) 반환
- 호출처 교체:
  - `src/components/sub-category-slider/sub-category-slider-container.tsx`
  - `src/components/recommend-carousel/recommend-category-container.tsx`
  - 타입 정합성 보정: `recommended-category-card`에서 `CategorySimple` 사용

### 2) 카테고리 메인(`/category`) UX 확장
- 파일: `src/app/category/page.tsx`
- 반영 내용:
  - `auth()` 기반 사용자 닉네임 조회 (`없으면 '사용자'`)
  - `getCategories()` + `getRecommendedSubCategories()` 병렬 조회
  - 추천 데이터가 비어있는 경우 fallback 추천 목록 생성
    - 전체 카테고리/서브카테고리 `displayOrder` 기준 정렬
    - 상위 8개 추천 카드 구성
  - `parentLookup` 매핑 구성 (`subCategoryId -> parentCategoryId`)
  - 최종 렌더를 `CategoryMainLayout`으로 전환

### 3) 메인 카테고리 전용 컴포넌트 신설
- 신규 파일:
  - `src/components/category/category-main-layout.tsx`
  - `src/components/category/category-main-header.tsx`
  - `src/components/category/category-main-recommend.tsx`
  - `src/components/category/category-main-parent-list.tsx`
  - `src/components/category/use-hide-on-scroll.ts`
- 핵심 동작:
  - 추천 섹션 스크롤 기반 show/hide
  - 캐러셀 + dot navigation으로 추천 카테고리 탐색 강화
  - parent 리스트 CTA를 명확한 타이포/아이콘 구조로 제공
  - 하단 `MainNavBar` 고정 배치 유지

### 4) parent/product 라우트 책임 분리
- 변경 파일:
  - `src/app/category/[parentId]/layout.tsx`
  - `src/app/category/[parentId]/page.tsx` (신규)
  - `src/app/category/[parentId]/[id]/layout.tsx` (신규)
  - `src/components/category/category-layout.tsx`
- 상세:
  - `parentId` 라우트에서 초기 카테고리 유효성 검사/리다이렉트 처리
  - `CategoryLayout`에 `initialCategoryId` 도입
    - 초기 진입 시 해당 탭으로 스크롤 동기화
  - product 하위 라우트 레이아웃에 상단 헤더 + 서브카테고리 슬라이더 배치

### 5) 공용/연결 UI 개선
- `src/components/recommend-carousel/recommend-carousel.tsx`
  - `showDots` 옵션 추가
  - 캐러셀 API 연동 + dot navigation 지원
- `src/components/category/category-parent-header-bar.tsx`
  - 카테고리 타이틀/검색창 구성 재정렬
  - sticky header의 시각적 계층 정리
- `src/components/product/product-header.tsx`
  - 뒤로가기 fallback 경로를 `/category`로 고정 

## 🧪 테스트/검증 포인트
### 카테고리 메인 (`/category`)
- 추천 데이터 정상 수신 시 카드/도트 네비게이션 렌더링 확인
- 추천 데이터 비어있을 때 fallback 추천 목록 생성 확인
- 스크롤 다운/업에 따른 추천 섹션 숨김/복원 애니메이션 확인
- 추천 카드 클릭 시 `parent/category` 경로 이동 정상 확인

### parent/product 라우트
- `/category/[parentId]` 진입 시 해당 탭 초기 동기화 확인
- 잘못된 `parentId` 접근 시 안전한 리다이렉트 동작 확인
- `/category/[parentId]/[id]`에서 상단 헤더/서브카테고리 슬라이더 노출 확인

### 공통
- 카테고리 관련 API 호출이 server action 경유로 동작하는지 확인
- 상품 상세 헤더 뒤로가기 fallback이 의도대로 `/category`로 동작하는지 확인
- 기존 카테고리 탐색/상품 이동 플로우 회귀 여부 확인

## ⚠️ 리스크 및 확인 필요사항
- `auth()` 세션 의존 구간에서 사용자 정보 미존재 시 기본 닉네임 처리 확인 필요
- 추천 데이터 fallback 로직이 비즈니스 우선순위(정렬/노출 수)와 일치하는지 PO 확인 필요
- route 분리 이후 deep-link 진입 케이스(`parentId`, `id`) 회귀 확인 필요

## ✅ 체크리스트
- [x] 기능 단위 커밋 분리
- [x] 카테고리 도메인 호출 구조 server action으로 통합
- [x] parent/product 라우트 책임 분리
- [x] 메인 카테고리 개인화 추천 영역 추가
- [x] 헤더/뒤로가기 동작 회귀 점검
