### PR TITLE
[FIX]: 리뷰 탭 전환 및 리뷰 문장 입력 UX 개선

### DIFF
--- a/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
+++ b/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
@@ -134,6 +134,8 @@ export default function ReviewWriteFlow({
   const [reviewImageUrls, setReviewImageUrls] = useState<string[]>([]);
   const [sizeReviewItems, setSizeReviewItems] = useState<string[]>([]);
   const [materialReviewItems, setMaterialReviewItems] = useState<string[]>([]);
+  const [sizeDraftReview, setSizeDraftReview] = useState('');
+  const [materialDraftReview, setMaterialDraftReview] = useState('');
   const sizeTextareaRefs = useRef<Array<HTMLTextAreaElement | null>>([]);
   const materialTextareaRefs = useRef<Array<HTMLTextAreaElement | null>>([]);
   const [pendingSizeFocusIndex, setPendingSizeFocusIndex] = useState<number | null>(
@@ -429,18 +431,18 @@ export default function ReviewWriteFlow({
     });
   };
 
-  const handleAddSizeReviewItem = () => {
-    setSizeReviewItems((prev) => {
-      setPendingSizeFocusIndex(prev.length);
-      return [...prev, ''];
-    });
+  const commitSizeDraftReview = () => {
+    const nextValue = sizeDraftReview.trim();
+    if (!nextValue) return;
+    setSizeReviewItems((prev) => [...prev, nextValue]);
+    setSizeDraftReview('');
   };
 
-  const handleAddMaterialReviewItem = () => {
-    setMaterialReviewItems((prev) => {
-      setPendingMaterialFocusIndex(prev.length);
-      return [...prev, ''];
-    });
+  const commitMaterialDraftReview = () => {
+    const nextValue = materialDraftReview.trim();
+    if (!nextValue) return;
+    setMaterialReviewItems((prev) => [...prev, nextValue]);
+    setMaterialDraftReview('');
   };
 
   const handleUploadReviewImages = (files: File[]) => {
@@ -891,26 +893,13 @@ export default function ReviewWriteFlow({
               <Image src="/icons/ai-star.svg" alt="" width={18} height={18} />
               <p className="text-2xl font-semibold text-[#1c1c1c]">사이즈 관련</p>
             </div>
-            <p className="text-sm text-[#7d7d7d]">
-              {sizeReviewItems.length === 0
-                ? '후기 문장 받아보기 버튼으로 문장을 생성할 수 있어요'
-                : '각 문장은 클릭해서 수정 할 수 있어요'}
+            <p className="text-base text-[#7d7d7d]">
+              후기 문장을 받거나 문장을 직접 추가할 수 있어요
             </p>
-            {sizeReviewItems.length === 0 ? (
-              <div>
-                <button
-                  type="button"
-                  onClick={handleAddSizeReviewItem}
-                  className="w-full rounded-lg border border-[#999] bg-white py-2 text-base font-medium text-[#1c1c1c]"
-                >
-                  직접 문장 추가
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <div className="divide-y divide-[#e3e3e3] rounded-md bg-white">
-                  {sizeReviewItems.map((item, index) => (
-                    <div key={`size-review-${index}`} className="flex items-center">
+            <div className="space-y-2">
+              <div className="divide-y divide-[#e3e3e3] rounded-md bg-white">
+                {sizeReviewItems.map((item, index) => (
+                  <div key={`size-review-${index}`} className="flex items-center">
                     <textarea
                       rows={1}
                       ref={(element) => {
@@ -925,7 +914,7 @@ export default function ReviewWriteFlow({
                           );
                         }
                       }}
-                      className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-transparent bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
+                      className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-[#d1d1d1] bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
                       value={item}
                       onChange={(e) => {
                           const next = [...sizeReviewItems];
@@ -945,18 +934,40 @@ export default function ReviewWriteFlow({
                       >
                         ×
                       </button>
-                    </div>
-                  ))}
+                  </div>
+                ))}
+                <div className="flex items-center">
+                  <textarea
+                    rows={1}
+                    enterKeyHint="done"
+                    placeholder="문장을 직접 입력해 주세요"
+                    onInput={(e) => autoResizeTextarea(e.currentTarget)}
+                    onKeyDown={(e) => {
+                      const nativeEvent = e.nativeEvent as KeyboardEvent;
+                      if (
+                        e.key === 'Enter' &&
+                        !e.shiftKey &&
+                        !nativeEvent.isComposing
+                      ) {
+                        e.preventDefault();
+                        commitSizeDraftReview();
+                      }
+                    }}
+                    className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-[#d1d1d1] bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
+                    value={sizeDraftReview}
+                    onChange={(e) => setSizeDraftReview(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={commitSizeDraftReview}
+                    className="px-4 text-[28px] leading-none text-[#8e8e8e]"
+                    aria-label="사이즈 문장 추가"
+                  >
+                    +
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={handleAddSizeReviewItem}
-                  className="w-full rounded-lg border border-[#999] bg-white py-2 text-base font-medium text-[#1c1c1c]"
-                >
-                  직접 문장 추가
-                </button>
               </div>
-            )}
+            </div>
           </div>
 
           <div className="space-y-3 bg-white px-5 py-4">
@@ -964,26 +975,13 @@ export default function ReviewWriteFlow({
               <Image src="/icons/ai-star.svg" alt="" width={18} height={18} />
               <p className="text-2xl font-semibold text-[#1c1c1c]">소재 관련</p>
             </div>
-            <p className="text-sm text-[#7d7d7d]">
-              {materialReviewItems.length === 0
-                ? '후기 문장 받아보기 버튼으로 문장을 생성할 수 있어요'
-                : '각 문장은 클릭해서 수정 할 수 있어요'}
+            <p className="text-base text-[#7d7d7d]">
+              후기 문장을 받거나 문장을 직접 추가할 수 있어요
             </p>
-            {materialReviewItems.length === 0 ? (
-              <div>
-                <button
-                  type="button"
-                  onClick={handleAddMaterialReviewItem}
-                  className="w-full rounded-lg border border-[#999] bg-white py-2 text-base font-medium text-[#1c1c1c]"
-                >
-                  직접 문장 추가
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <div className="divide-y divide-[#e3e3e3] rounded-md bg-white">
-                  {materialReviewItems.map((item, index) => (
-                    <div key={`material-review-${index}`} className="flex items-center">
+            <div className="space-y-2">
+              <div className="divide-y divide-[#e3e3e3] rounded-md bg-white">
+                {materialReviewItems.map((item, index) => (
+                  <div key={`material-review-${index}`} className="flex items-center">
                     <textarea
                       rows={1}
                       ref={(element) => {
@@ -998,7 +996,7 @@ export default function ReviewWriteFlow({
                           );
                         }
                       }}
-                      className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-transparent bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
+                      className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-[#d1d1d1] bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
                       value={item}
                       onChange={(e) => {
                           const next = [...materialReviewItems];
@@ -1018,18 +1016,40 @@ export default function ReviewWriteFlow({
                       >
                         ×
                       </button>
-                    </div>
-                  ))}
+                  </div>
+                ))}
+                <div className="flex items-center">
+                  <textarea
+                    rows={1}
+                    enterKeyHint="done"
+                    placeholder="문장을 직접 입력해 주세요"
+                    onInput={(e) => autoResizeTextarea(e.currentTarget)}
+                    onKeyDown={(e) => {
+                      const nativeEvent = e.nativeEvent as KeyboardEvent;
+                      if (
+                        e.key === 'Enter' &&
+                        !e.shiftKey &&
+                        !nativeEvent.isComposing
+                      ) {
+                        e.preventDefault();
+                        commitMaterialDraftReview();
+                      }
+                    }}
+                    className="min-h-[56px] w-full resize-none overflow-hidden rounded-md border border-[#d1d1d1] bg-transparent px-4 py-4 text-lg leading-[1.35] font-medium whitespace-pre-wrap break-words text-[#1c1c1c] outline-none focus:border-ongil-teal focus:outline focus:outline-1 focus:outline-ongil-teal"
+                    value={materialDraftReview}
+                    onChange={(e) => setMaterialDraftReview(e.target.value)}
+                  />
+                  <button
+                    type="button"
+                    onClick={commitMaterialDraftReview}
+                    className="px-4 text-[28px] leading-none text-[#8e8e8e]"
+                    aria-label="소재 문장 추가"
+                  >
+                    +
+                  </button>
                 </div>
-                <button
-                  type="button"
-                  onClick={handleAddMaterialReviewItem}
-                  className="w-full rounded-lg border border-[#999] bg-white py-2 text-base font-medium text-[#1c1c1c]"
-                >
-                  직접 문장 추가
-                </button>
               </div>
-            )}
+            </div>
           </div>
 
           <label className="mx-5 block text-sm">

--- a/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
+++ b/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
@@ -369,7 +369,7 @@ export default function ReviewWriteFlow({
       }
 
       setSuccessMessage('리뷰 제출 완료');
-      router.replace('/reviews');
+      router.replace('/reviews?tab=written');
     });
   };
 

--- a/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
+++ b/src/app/review/write/[reviewId]/_components/review-write-flow.tsx
@@ -1056,7 +1056,7 @@ export default function ReviewWriteFlow({
             <span className="text-2xl font-semibold text-black">기타</span>
             <textarea
               placeholder="추가로 하고싶은 말을 적어주세요"
-              className="mt-3 min-h-24 w-full rounded border border-[#cfcfcf] px-3 py-2"
+              className="mt-3 min-h-24 w-full rounded border border-[#cfcfcf] px-3 py-2 text-base"
               value={textReview}
               onChange={(e) => setTextReview(e.target.value)}
             />

--- a/src/components/reviews/review-management-content.tsx
+++ b/src/components/reviews/review-management-content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import {
   ProductWithReviewStats,
@@ -21,7 +21,24 @@ export default function ReviewManagementContent({
   writtenReviews,
   writtenTotalCount,
 }: ReviewManagementContentProps) {
-  const [activeTab, setActiveTab] = useState<ReviewTab>('writable');
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const activeTab: ReviewTab = tabParam === 'written' ? 'written' : 'writable';
+
+  const handleTabChange = (tab: ReviewTab) => {
+    if (tabParam === tab) {
+      return;
+    }
+
+    const nextParams = new URLSearchParams(searchParams.toString());
+    nextParams.set('tab', tab);
+    const nextSearch = nextParams.toString();
+    const nextHref = nextSearch ? `${pathname}?${nextSearch}` : pathname;
+
+    router.replace(nextHref, { scroll: false });
+  };
 
   return (
     <section className="px-5 py-6">
@@ -29,7 +46,7 @@ export default function ReviewManagementContent({
         writableCount={pendingReviews.length}
         writtenCount={writtenTotalCount}
         activeTab={activeTab}
-        onTabChange={setActiveTab}
+        onTabChange={handleTabChange}
       />
 
       {activeTab === 'writable' ? (


### PR DESCRIPTION
## 📝 개요

- 리뷰 작성 완료 후 `/reviews`로 돌아왔을 때 작성 대기 탭이 선택되던 문제를 수정했습니다.
- 리뷰 관리 탭 상태를 URL 쿼리(`tab`)와 동기화해 리다이렉트/새로고침 시에도 의도한 탭이 유지되도록 개선했습니다.
- 리뷰 작성 Step2의 문장 입력 UX를 개편해, `후기 문장 받아보기` 단일 흐름과 모바일 완료(Enter) 기반 직접 입력 추가를 지원합니다.

## 🚀 주요 변경 사항

- [x] 리뷰 작성 완료 후 작성 리뷰 탭 자동 노출
  - `src/app/review/write/[reviewId]/_components/review-write-flow.tsx`
  - 제출 성공 시 `router.replace('/reviews?tab=written')`로 변경

- [x] 리뷰 관리 탭 URL 동기화
  - `src/components/reviews/review-management-content.tsx`
  - `?tab=writable|written` 파싱으로 활성 탭 결정
  - 탭 클릭 시 기존 쿼리 유지 + `tab`만 갱신
  - 동일 탭 재클릭 시 라우팅 생략, `scroll: false` 적용

- [x] Step2 문장 생성/입력 UX 개선
  - `src/app/review/write/[reviewId]/_components/review-write-flow.tsx`
  - 사이즈/소재 개별 생성 버튼 제거, `후기 문장 받아보기`로 통합
  - 선택 조건에 따라 사이즈/소재/둘 다 생성
  - 같은 조건으로는 재생성하지 않도록 조건 키 기반 재요청 방지

- [x] 직접 문장 추가 UX 개편 (모바일 우선)
  - `직접 문장 추가` 버튼 제거
  - 섹션별 빈 textarea 1개 상시 노출 + `+` 버튼으로 추가
  - 추가된 문장 행은 `x` 버튼으로 삭제
  - 모바일 완료/PC Enter로 문장 확정 추가 (`Shift+Enter` 줄바꿈, IME 조합 보호)

- [x] 텍스트 스타일 보정
  - 문장 입력 안내 문구를 통일하고 가독성 향상(`text-base`)
  - 문장 입력 textarea 기본 회색 보더 적용
  - 기타 입력란 폰트 크기 상향(`text-base`)

## 📸 스크린샷 (선택)

|       기능 구현 화면       |
| :------------------------: |
| 사진을 여기에 드래그하세요 |

## ✅ 체크리스트

- [ ] 빌드 테스트를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 console.log는 제거했나요?
- [x] 변경 파일 기준 lint 확인 완료

## 이슈 해결 여부

- 별도 이슈 번호 연결 없이 작업했습니다.
