### PR TITLE
[REFACTOR]: 상품 리뷰 탭 UX 개선

### DIFF
--- a/src/components/product/review/ai-material-carousel.tsx
+++ b/src/components/product/review/ai-material-carousel.tsx
@@ -1,12 +1,16 @@
 'use client';
+import { useState } from 'react';
 import Image from 'next/image';
 import { MaterialDescription } from '@/types/domain/product';
 import {
   Carousel,
+  type CarouselApi,
   CarouselContent,
   CarouselItem,
 } from '@/components/ui/carousel';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useCarouselDots } from '@/components/banner-carousel/use-carousel-dots';
+import { DotNavigation } from '@/components/banner-carousel/dot-navigation';
 import { cn } from '@/lib/utils';
 
 interface AiMaterialCarouselProps {
@@ -25,6 +29,9 @@ export default function AiMaterialCarousel({
   materialDescription,
   materialName,
 }: AiMaterialCarouselProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const { current, count, scrollTo } = useCarouselDots(api);
+
   if (!materialDescription) {
     return (
       <div className="py-10 text-center text-gray-500">
@@ -66,6 +73,7 @@ export default function AiMaterialCarousel({
       </div>
 
       <Carousel
+        setApi={setApi}
         opts={{
           align: 'start',
           loop: true,
@@ -113,6 +121,12 @@ export default function AiMaterialCarousel({
           ))}
         </CarouselContent>
       </Carousel>
+      <DotNavigation
+        count={count}
+        current={current}
+        onDotClick={scrollTo}
+        className="pt-4 pb-0"
+      />
     </div>
   );
 }

--- a/src/components/product/review/review-item.tsx
+++ b/src/components/product/review/review-item.tsx
@@ -112,8 +112,7 @@ export default function ReviewItem({
     : createdAtDate.toISOString().slice(0, 10).replace(/-/g, '.');
   const answers =
     review.initialFirstAnswers ?? review.answers ?? DEFAULT_ANSWERS;
-  const colorText =
-    EVALUATION_MAP[answers.colorAnswer] || answers.colorAnswer || '정보 없음';
+  const colorText = EVALUATION_MAP[answers.colorAnswer] || answers.colorAnswer;
   const fitIssueParts = normalizeToList(
     review.initialSecondAnswers?.fitIssueParts,
   );
@@ -207,32 +206,37 @@ export default function ReviewItem({
         {REVIEW_CONTENT_CONFIG.filter((item) => item.key !== 'textReview').map(
           ({ label, key }) => {
             const text = reviewTextByKey[key];
+            if (!text) return null;
 
             return (
               <div key={key} className="flex flex-col gap-4 text-xl">
                 <span className="min-w-[30px] text-2xl font-bold">{label}</span>
                 <ul className="list-disc gap-2 pl-10">
-                  <li className="mb-3">{text || '정보 없음'}</li>
+                  <li className="mb-3">{text}</li>
                 </ul>
               </div>
             );
           },
         )}
 
-        <div className="flex flex-col gap-4 text-xl">
-          <span className="min-w-[30px] text-2xl font-bold">색감</span>
-          <ul className="list-disc gap-2 pl-10">
-            <li className="mb-3">{colorText}</li>
-          </ul>
-        </div>
-
-        <div className="flex flex-col gap-4 text-xl">
-          <span className="min-w-[30px] text-2xl font-bold">기타</span>
-          <div className="mb-3 flex items-center gap-2 pl-3">
-            <MessageCircle className="text-ongil-teal h-6 w-6" />
-            <p>{review.textReview || '정보 없음'}</p>
+        {colorText && (
+          <div className="flex flex-col gap-4 text-xl">
+            <span className="min-w-[30px] text-2xl font-bold">색감</span>
+            <ul className="list-disc gap-2 pl-10">
+              <li className="mb-3">{colorText}</li>
+            </ul>
           </div>
-        </div>
+        )}
+
+        {review.textReview && (
+          <div className="flex flex-col gap-4 text-xl">
+            <span className="min-w-[30px] text-2xl font-bold">기타</span>
+            <div className="mb-3 flex items-center gap-2 pl-3">
+              <MessageCircle className="text-ongil-teal h-6 w-6" />
+              <p>{review.textReview}</p>
+            </div>
+          </div>
+        )}
 
         {fitIssueParts.length > 0 && (
           <div className="flex flex-col gap-4 text-xl">

--- a/src/components/product/review/review-section.tsx
+++ b/src/components/product/review/review-section.tsx
@@ -67,8 +67,6 @@ function createEmptyStats(oneMonthReviewCount: number): ReviewStatsData {
   };
 }
 
-const REVIEW_FILTER_STICKY_TOP = 188;
-
 /**
  * 상품 리뷰 섹션 컴포넌트, 리뷰 탭, 필터, 정렬, 리뷰 리스트 포함
  * 리뷰 관련 모든 UI와 상태 관리를 담당
@@ -137,8 +135,6 @@ export default function ProductReviewContent({
     setFilters((prev) => ({ ...prev, ...newFilters }));
   };
 
-  if (isTotallyEmpty) return <EmptyReviewState />;
-
   return (
     <div className="flex flex-col gap-6 space-y-0 pb-10">
       {/* 1. 상단 AI 소재 분석 캐러셀 */}
@@ -151,83 +147,84 @@ export default function ProductReviewContent({
 
       <div className="h-2 w-full bg-gray-100" />
 
-      {/* 2. 리뷰 타이틀 및 개수 */}
-      <div className="mt-[20px] px-4 leading-normal font-semibold not-italic">
-        <span className="text-3xl">리뷰 </span>
-        <span className="text-ongil-teal text-3xl">
-          {stats.initialReviewCount + stats.oneMonthReviewCount}
-        </span>
-      </div>
+      {isTotallyEmpty ? (
+        <EmptyReviewState />
+      ) : (
+        <>
+          {/* 2. 리뷰 타이틀 및 개수 */}
+          <div className="mt-[20px] px-4 leading-normal font-semibold not-italic">
+            <span className="text-3xl">리뷰 </span>
+            <span className="text-ongil-teal text-3xl">
+              {stats.initialReviewCount + stats.oneMonthReviewCount}
+            </span>
+          </div>
 
-      {/* 3. 탭 (전체 / 한달 사용) */}
-      <ReviewTabs
-        activeTab={activeReviewTab}
-        onTabChange={handleTabChange}
-        generalCount={stats.initialReviewCount}
-        monthCount={stats.oneMonthReviewCount}
-      />
+          {/* 3. 탭 (전체 / 한달 사용) */}
+          <ReviewTabs
+            activeTab={activeReviewTab}
+            onTabChange={handleTabChange}
+            generalCount={stats.initialReviewCount}
+            monthCount={stats.oneMonthReviewCount}
+          />
 
-      <>
-        {isMonthTabEmpty ? (
-          <EmptyReviewState variant="month" />
-        ) : (
-          <>
-            {/* 통계 요약 섹션 */}
-            <ReviewSummarySection
-              productId={productInfo.productId}
-              reviewType={activeReviewTab === 'month' ? 'ONE_MONTH' : 'INITIAL'}
-              recommendedSize={productInfo.recommendedSize}
-              stats={currentDisplayStats}
-              reviewCount={currentTotalCount}
-              availableOptions={productInfo.availableOptions}
-            />
+          {isMonthTabEmpty ? (
+            <EmptyReviewState variant="month" />
+          ) : (
+            <>
+              {/* 통계 요약 섹션 */}
+              <ReviewSummarySection
+                productId={productInfo.productId}
+                reviewType={activeReviewTab === 'month' ? 'ONE_MONTH' : 'INITIAL'}
+                recommendedSize={productInfo.recommendedSize}
+                stats={currentDisplayStats}
+                reviewCount={currentTotalCount}
+                availableOptions={productInfo.availableOptions}
+              />
 
-            {/* Sticky 필터/정렬 바 */}
-            <div
-              className="sticky z-20 flex flex-col gap-3 bg-white px-4 py-3 transition-all"
-              style={{ top: REVIEW_FILTER_STICKY_TOP }}
-            >
-              {/* 내 사이즈 보기 스위치 */}
-              <div className="flex justify-end space-x-2">
-                <div className="flex items-center space-x-2">
-                  <Switch
-                    id="my-size-mode"
-                    checked={filters.mySize}
-                    onCheckedChange={handleMySizeToggle}
-                    className="data-[state=checked]:bg-[#34C759]"
+              {/* 필터/정렬 바 */}
+              <div className="z-20 flex flex-col gap-3 bg-white px-4 py-3 transition-all">
+                {/* 내 사이즈 보기 스위치 */}
+                <div className="flex justify-end space-x-2">
+                  <div className="flex items-center space-x-2">
+                    <Switch
+                      id="my-size-mode"
+                      checked={filters.mySize}
+                      onCheckedChange={handleMySizeToggle}
+                      className="data-[state=checked]:bg-[#34C759]"
+                    />
+                    <Label
+                      htmlFor="my-size-mode"
+                      className="cursor-pointer text-2xl leading-normal font-medium not-italic"
+                    >
+                      내 사이즈만 보기
+                    </Label>
+                  </div>
+                </div>
+                <div className="border-ongil-teal flex items-center justify-between border-y py-[10px]">
+                  <ReviewOptionSheet
+                    availableSizes={productInfo.availableOptions.sizes}
+                    availableColors={productInfo.availableOptions.colors}
+                    filters={filters}
+                    onApply={handleApplyFilters}
                   />
-                  <Label
-                    htmlFor="my-size-mode"
-                    className="cursor-pointer text-2xl leading-normal font-medium not-italic"
-                  >
-                    내 사이즈만 보기
-                  </Label>
+                  <ReviewSortSheet
+                    currentSort={sortOption}
+                    onSortChange={setSortOption}
+                  />
                 </div>
               </div>
-              <div className="border-ongil-teal flex items-center justify-between border-y py-[10px]">
-                <ReviewOptionSheet
-                  availableSizes={productInfo.availableOptions.sizes}
-                  availableColors={productInfo.availableOptions.colors}
-                  filters={filters}
-                  onApply={handleApplyFilters}
-                />
-                <ReviewSortSheet
-                  currentSort={sortOption}
-                  onSortChange={setSortOption}
-                />
-              </div>
-            </div>
 
-            {/* 리뷰 리스트 */}
-            <ReviewList
-              productId={productInfo.productId}
-              activeTab={activeReviewTab}
-              filters={filters}
-              sortOption={sortOption}
-            />
-          </>
-        )}
-      </>
+              {/* 리뷰 리스트 */}
+              <ReviewList
+                productId={productInfo.productId}
+                activeTab={activeReviewTab}
+                filters={filters}
+                sortOption={sortOption}
+              />
+            </>
+          )}
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📝 개요

- 상품 상세 `/product/[id]`의 리뷰 탭 UX를 정리했습니다.
- 리뷰 필터 바의 sticky 동작을 제거해 스크롤 시 자연스럽게 흐르도록 변경했습니다.
- 리뷰 카드에서 값이 없는 항목은 섹션 자체를 숨기고 `정보 없음` 문구 노출을 제거했습니다.
- 리뷰가 0건이어도 상단 AI 소재 설명은 항상 보이도록 렌더링 구조를 조정했습니다.
- AI 소재 설명 캐러셀에 dot 네비게이터를 추가했습니다.
- 관련 이슈 번호: #<이슈번호>

## 🚀 주요 변경 사항

- [x] 리뷰 필터 sticky 제거
- [x] 리뷰 카드 빈값 섹션 미노출 처리
- [x] 리뷰 0건 상태에서도 AI 소재 설명 노출
- [x] AI 소재 설명 캐러셀 dot 네비게이터 추가

### 1) 리뷰 섹션 렌더링 구조 정리 (`review-section.tsx`)

- `REVIEW_FILTER_STICKY_TOP` 상수 및 필터 바 `sticky` 스타일 제거
- 기존 조기 반환(`if (isTotallyEmpty) return ...`) 제거
- 렌더링 순서를 다음으로 고정
- 상단 AI 소재 캐러셀 항상 렌더
- 구분선 렌더
- 리뷰 총합 0건이면 `EmptyReviewState`만 렌더
- 리뷰가 있으면 기존 리뷰 타이틀/탭/통계/필터/리스트 렌더
- `isMonthTabEmpty` 분기는 유지

### 2) 리뷰 카드 빈값 UI 정리 (`review-item.tsx`)

- `colorText` fallback의 `정보 없음` 제거
- `sizeReview`, `materialReview` 값이 없으면 해당 섹션 미렌더
- `색감` 섹션은 값이 있을 때만 렌더
- `기타` 섹션은 `review.textReview`가 있을 때만 렌더
- 결과적으로 리뷰 카드에서 `정보 없음` 문자열이 노출되지 않음

### 3) AI 소재 캐러셀 dot 네비게이터 추가 (`ai-material-carousel.tsx`)

- `CarouselApi` + `setApi` 패턴 도입
- `useCarouselDots` 훅 연동
- `DotNavigation` 컴포넌트 하단 추가
- dot 노출은 항상 시도하고, 실제 렌더 여부는 `DotNavigation`의 `count <= 1` 조건에 위임

## 📂 변경 파일

- `src/components/product/review/review-section.tsx`
- `src/components/product/review/review-item.tsx`
- `src/components/product/review/ai-material-carousel.tsx`

## 🔍 동작/검증 결과

- 정적 검사
- `pnpm eslint src/components/product/review/review-section.tsx src/components/product/review/review-item.tsx src/components/product/review/ai-material-carousel.tsx` 통과
- 수동 QA
- 로컬 브라우저 수동 검증은 별도 진행 필요

## 📸 스크린샷 (선택)

| 기능 구현 화면 |
| :--: |
| 리뷰 필터 sticky 제거 후 스크롤 화면 |
| 리뷰 0건 상태에서 AI 소재 설명 노출 화면 |
| AI 소재 캐러셀 dot 네비게이터 노출 화면 |

## ⚠️ 영향 범위 / 리스크

- 리뷰 탭의 스크롤 체감이 변경됩니다(필터 고정 제거).
- 리뷰 카드에서 빈 섹션을 숨기므로 카드 높이/정보 밀도가 데이터에 따라 달라집니다.
- AI 소재 캐러셀 dot은 슬라이드 수에 따라 자동 표시/숨김됩니다.

## ✅ 체크리스트

- [ ] 빌드 테스트(`pnpm build`)를 완료했나요?
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 `console.log`는 제거했나요?
- [ ] 타입 체크(`tsc --noEmit`)를 통과했나요?
- [x] ESLint 검사를 통과했나요?

## 이슈 해결 여부

Closes #<이슈번호>
