### PR TITLE
feat: 카테고리 필터 바텀시트 UI 및 API 파라미터 정렬

### DIFF
--- a/src/app/category/[parentId]/[id]/page.tsx
+++ b/src/app/category/[parentId]/[id]/page.tsx
@@ -7,9 +7,9 @@ interface PageProps {
   searchParams: Promise<{
     sortType?: string;
     page?: string;
-    clothingSize?: string | string[];
+    clothingSizes?: string | string[];
     priceRange?: string | string[];
-    brand?: string | string[];
+    brandIds?: string | string[];
   }>;
 }
 

--- a/src/app/category/[parentId]/[id]/page.tsx
+++ b/src/app/category/[parentId]/[id]/page.tsx
@@ -1,10 +1,16 @@
 import ProductListContainer from '@/components/product/product-list-container';
-import { ProductFilterBar } from '@/components/product/product-filter-bar';
+import ProductFilterBarContainer from '@/components/product/product-filter-bar-container';
 import { Suspense } from 'react';
 
 interface PageProps {
   params: Promise<{ parentId: string; id: string }>;
-  searchParams: Promise<{ sortType?: string; page?: string }>;
+  searchParams: Promise<{
+    sortType?: string;
+    page?: string;
+    clothingSize?: string | string[];
+    priceRange?: string | string[];
+    brand?: string | string[];
+  }>;
 }
 
 export default function ProductListPage({ params, searchParams }: PageProps) {
@@ -12,12 +18,15 @@ export default function ProductListPage({ params, searchParams }: PageProps) {
     <div className="mx-auto max-w-7xl px-4">
       <Suspense
         fallback={
-          <div className="mb-4 flex items-center justify-end">
-            <div className="h-10 w-24 animate-pulse rounded-md bg-gray-200" />
+          <div className="mb-4 flex items-center gap-2">
+            <div className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
+            <div className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
+            <div className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
+            <div className="h-10 w-20 animate-pulse rounded-full bg-gray-200" />
           </div>
         }
       >
-        <ProductFilterBar />
+        <ProductFilterBarContainer params={params} searchParams={searchParams} />
       </Suspense>
 
       <Suspense

--- a/src/components/product/product-filter-bar-container.tsx
+++ b/src/components/product/product-filter-bar-container.tsx
@@ -15,13 +15,7 @@ interface ProductFilterBarContainerProps {
   }>;
 }
 
-const PRICE_OPTIONS = [
-  '5만원 이하',
-  '5-10만원',
-  '10-15만원',
-  '15-20만원',
-  '20만원 이상',
-] as const;
+const PRICE_RANGE_PATTERN = /^\d+-\d+$/;
 
 function normalizeArray(value?: string | string[]) {
   if (Array.isArray(value)) {
@@ -31,6 +25,13 @@ function normalizeArray(value?: string | string[]) {
     return [value];
   }
   return [];
+}
+
+function normalizePriceRange(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value[0] ?? '';
+  }
+  return value ?? '';
 }
 
 export default async function ProductFilterBarContainer({
@@ -62,9 +63,10 @@ export default async function ProductFilterBarContainer({
     ['XS', 'S', 'M', 'L', 'XL'].includes(size),
   );
 
-  const priceOptions = normalizeArray(query.priceRange).filter((price) =>
-    PRICE_OPTIONS.includes(price as (typeof PRICE_OPTIONS)[number]),
-  );
+  const rawPriceRange = normalizePriceRange(query.priceRange);
+  const safePriceRange = PRICE_RANGE_PATTERN.test(rawPriceRange)
+    ? rawPriceRange
+    : '';
 
   const [subCategories, result] = await Promise.all([
     Number.isFinite(parsedParentId)
@@ -77,7 +79,7 @@ export default async function ProductFilterBarContainer({
         page: 0,
         size: 36,
         clothingSize: sizeOptions.length > 0 ? sizeOptions : undefined,
-        priceRange: priceOptions.length > 0 ? priceOptions : undefined,
+        priceRange: safePriceRange || undefined,
       },
     }),
   ]);

--- a/src/components/product/product-filter-bar-container.tsx
+++ b/src/components/product/product-filter-bar-container.tsx
@@ -1,0 +1,100 @@
+import { getSubCategories } from '@/app/actions/category';
+import { api } from '@/lib/api-client';
+import { ProductSearchResult } from '@/types/domain/product';
+import { ProductSortType } from '@/types/enums';
+import { ProductFilterBar } from './product-filter-bar';
+
+interface ProductFilterBarContainerProps {
+  params: Promise<{ parentId: string; id: string }>;
+  searchParams: Promise<{
+    sortType?: string;
+    page?: string;
+    clothingSize?: string | string[];
+    priceRange?: string | string[];
+    brand?: string | string[];
+  }>;
+}
+
+const PRICE_OPTIONS = [
+  '5만원 이하',
+  '5-10만원',
+  '10-15만원',
+  '15-20만원',
+  '20만원 이상',
+] as const;
+
+function normalizeArray(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => item.trim().length > 0);
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return [value];
+  }
+  return [];
+}
+
+export default async function ProductFilterBarContainer({
+  params,
+  searchParams,
+}: ProductFilterBarContainerProps) {
+  const [{ parentId, id: subCategoryId }, query] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+
+  const parsedCategoryId = Number(subCategoryId);
+  const parsedParentId = Number(parentId);
+  const safeCategoryId =
+    Number.isFinite(parsedCategoryId) && parsedCategoryId > 0
+      ? parsedCategoryId
+      : null;
+
+  if (safeCategoryId === null) {
+    return <ProductFilterBar parentCategoryName="" availableBrands={[]} />;
+  }
+
+  const sortValues = Object.values(ProductSortType);
+  const safeSortType = sortValues.includes(query.sortType as ProductSortType)
+    ? (query.sortType as ProductSortType)
+    : ProductSortType.POPULAR;
+
+  const sizeOptions = normalizeArray(query.clothingSize).filter((size) =>
+    ['XS', 'S', 'M', 'L', 'XL'].includes(size),
+  );
+
+  const priceOptions = normalizeArray(query.priceRange).filter((price) =>
+    PRICE_OPTIONS.includes(price as (typeof PRICE_OPTIONS)[number]),
+  );
+
+  const [subCategories, result] = await Promise.all([
+    Number.isFinite(parsedParentId)
+      ? getSubCategories(parsedParentId)
+      : Promise.resolve([]),
+    api.get<ProductSearchResult>('/products', {
+      params: {
+        categoryId: safeCategoryId,
+        sortType: safeSortType,
+        page: 0,
+        size: 36,
+        clothingSize: sizeOptions.length > 0 ? sizeOptions : undefined,
+        priceRange: priceOptions.length > 0 ? priceOptions : undefined,
+      },
+    }),
+  ]);
+
+  const parentCategoryName = subCategories[0]?.parentCategoryName ?? '';
+  const availableBrands = Array.from(
+    new Set(
+      result.products.content
+        .map((product) => product.brandName.trim())
+        .filter((brandName) => brandName.length > 0),
+    ),
+  ).sort((a, b) => a.localeCompare(b, 'ko'));
+
+  return (
+    <ProductFilterBar
+      parentCategoryName={parentCategoryName}
+      availableBrands={availableBrands}
+    />
+  );
+}

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -4,9 +4,9 @@ import { useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ProductSortType } from '@/types/enums';
 
-const SORT_OPTIONS = [
+const SORT_OPTIONS: { value: ProductSortType; label: string }[] = [
   { value: ProductSortType.POPULAR, label: '인기순' },
-  { value: ProductSortType.REVIEW, label: '후기순' },
+  { value: ProductSortType.REVIEW, label: '리뷰 많은순' },
   { value: ProductSortType.PRICE_LOW, label: '낮은 가격순' },
   { value: ProductSortType.PRICE_HIGH, label: '높은 가격순' },
 ];
@@ -20,7 +20,7 @@ export function ProductFilterBar() {
   const currentLabel =
     SORT_OPTIONS.find((opt) => opt.value === currentSort)?.label || '인기순';
 
-  const handleSortChange = (sortType: string) => {
+  const handleSortChange = (sortType: ProductSortType) => {
     const params = new URLSearchParams(searchParams.toString());
     params.set('sortType', sortType);
     router.push(`?${params.toString()}`, { scroll: false });
@@ -31,6 +31,7 @@ export function ProductFilterBar() {
     <>
       <div className="mb-4 flex items-center justify-end gap-2">
         <button
+          type="button"
           onClick={() => setIsOpen(true)}
           className="flex items-center gap-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-50"
         >
@@ -56,21 +57,23 @@ export function ProductFilterBar() {
         <>
           {/* 배경 오버레이 */}
           <div
-            className="fixed inset-0 z-50 bg-black/50"
+            className="fixed inset-0 z-50 bg-black/10"
             onClick={() => setIsOpen(false)}
           />
 
           {/* 바텀 시트 */}
-          <div className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl bg-white transition-transform duration-300 ease-out">
-            <div className="p-4">
-              <div className="mb-4 flex items-center justify-between">
-                <h3 className="text-lg font-bold">정렬</h3>
+          <div className="fixed inset-x-0 bottom-0 z-50 rounded-t-[22px] bg-white px-6 pt-6 pb-10 shadow-[0_-6px_20px_rgba(0,0,0,0.08)] transition-transform duration-300 ease-out">
+            <div className="mx-auto w-full max-w-7xl">
+              <div className="relative mb-8 flex items-center justify-center">
+                <h3 className="text-[34px] leading-none font-bold text-black">정렬</h3>
                 <button
+                  type="button"
                   onClick={() => setIsOpen(false)}
-                  className="rounded-full p-1 hover:bg-gray-100"
+                  className="absolute right-0 flex h-10 w-10 items-center justify-center rounded-full border border-[#707070] text-[#707070] hover:bg-gray-50"
+                  aria-label="정렬 시트 닫기"
                 >
                   <svg
-                    className="h-6 w-6"
+                    className="h-5 w-5"
                     fill="none"
                     stroke="currentColor"
                     viewBox="0 0 24 24"
@@ -85,18 +88,39 @@ export function ProductFilterBar() {
                 </button>
               </div>
 
-              <div className="space-y-2">
+              <div className="space-y-8">
                 {SORT_OPTIONS.map((option) => (
                   <button
+                    type="button"
                     key={option.value}
                     onClick={() => handleSortChange(option.value)}
-                    className={`w-full rounded-lg px-4 py-3 text-left transition-colors ${
-                      currentSort === option.value
-                        ? 'bg-gray-100 font-bold text-black'
-                        : 'text-gray-700 hover:bg-gray-50'
-                    }`}
+                    className="flex w-full items-center gap-4 text-left"
                   >
-                    {option.label}
+                    <span
+                      className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-[6px] border-2 ${
+                        currentSort === option.value
+                          ? 'border-ongil-teal bg-ongil-teal text-white'
+                          : 'border-ongil-teal bg-transparent text-transparent'
+                      }`}
+                      aria-hidden="true"
+                    >
+                      <svg
+                        className="h-5 w-5"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth={3}
+                          d="M5 13l4 4L19 7"
+                        />
+                      </svg>
+                    </span>
+                    <span className="text-[40px] leading-none font-bold text-black">
+                      {option.label}
+                    </span>
                   </button>
                 ))}
               </div>

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -6,7 +6,31 @@ import { getMyWishlist } from '@/app/actions/wishlist';
 
 interface ProductListContainerProps {
   params: Promise<{ parentId: string; id: string }>;
-  searchParams: Promise<{ sortType?: string; page?: string }>;
+  searchParams: Promise<{
+    sortType?: string;
+    page?: string;
+    clothingSize?: string | string[];
+    priceRange?: string | string[];
+    brand?: string | string[];
+  }>;
+}
+
+const PRICE_OPTIONS = [
+  '5만원 이하',
+  '5-10만원',
+  '10-15만원',
+  '15-20만원',
+  '20만원 이상',
+] as const;
+
+function normalizeArray(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => item.trim().length > 0);
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return [value];
+  }
+  return [];
 }
 
 export default async function ProductListContainer({
@@ -14,7 +38,12 @@ export default async function ProductListContainer({
   searchParams,
 }: ProductListContainerProps) {
   const { parentId, id: subCategoryId } = await params;
-  const { sortType = ProductSortType.POPULAR, page = '0' } = await searchParams;
+  const {
+    sortType = ProductSortType.POPULAR,
+    page = '0',
+    clothingSize,
+    priceRange,
+  } = await searchParams;
 
   // 쿼리 파라미터 검증
   const validSortTypes = Object.values(ProductSortType);
@@ -24,6 +53,12 @@ export default async function ProductListContainer({
 
   const safePage =
     Number.isFinite(Number(page)) && Number(page) >= 0 ? Number(page) : 0;
+  const safeClothingSize = normalizeArray(clothingSize).filter((size) =>
+    ['XS', 'S', 'M', 'L', 'XL'].includes(size),
+  );
+  const safePriceRange = normalizeArray(priceRange).filter((price) =>
+    PRICE_OPTIONS.includes(price as (typeof PRICE_OPTIONS)[number]),
+  );
 
   // subCategoryId 유효성 검증
   const parsedCategoryId = Number(subCategoryId);
@@ -43,6 +78,9 @@ export default async function ProductListContainer({
         sortType: safeSortType,
         page: safePage,
         size: 36,
+        clothingSize: safeClothingSize.length > 0 ? safeClothingSize : undefined,
+        priceRange: safePriceRange.length > 0 ? safePriceRange : undefined,
+        // 1차 구현에서는 brandId 연동 없이 브랜드 UI/URL 상태만 제공합니다.
       },
     }),
     getMyWishlist(),

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -9,9 +9,9 @@ interface ProductListContainerProps {
   searchParams: Promise<{
     sortType?: string;
     page?: string;
-    clothingSize?: string | string[];
+    clothingSizes?: string | string[];
     priceRange?: string | string[];
-    brand?: string | string[];
+    brandIds?: string | string[];
   }>;
 }
 
@@ -42,8 +42,9 @@ export default async function ProductListContainer({
   const {
     sortType = ProductSortType.POPULAR,
     page = '0',
-    clothingSize,
+    clothingSizes,
     priceRange,
+    brandIds,
   } = await searchParams;
 
   // 쿼리 파라미터 검증
@@ -54,9 +55,13 @@ export default async function ProductListContainer({
 
   const safePage =
     Number.isFinite(Number(page)) && Number(page) >= 0 ? Number(page) : 0;
-  const safeClothingSize = normalizeArray(clothingSize).filter((size) =>
+  const safeClothingSizes = normalizeArray(clothingSizes).filter((size) =>
     ['XS', 'S', 'M', 'L', 'XL'].includes(size),
   );
+  const safeBrandIds = normalizeArray(brandIds).filter((value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0;
+  });
   const rawPriceRange = normalizePriceRange(priceRange);
   const safePriceRange = PRICE_RANGE_PATTERN.test(rawPriceRange)
     ? rawPriceRange
@@ -80,9 +85,10 @@ export default async function ProductListContainer({
         sortType: safeSortType,
         page: safePage,
         size: 36,
-        clothingSize: safeClothingSize.length > 0 ? safeClothingSize : undefined,
+        clothingSizes:
+          safeClothingSizes.length > 0 ? safeClothingSizes : undefined,
         priceRange: safePriceRange || undefined,
-        // 1차 구현에서는 brandId 연동 없이 브랜드 UI/URL 상태만 제공합니다.
+        brandIds: safeBrandIds.length > 0 ? safeBrandIds : undefined,
       },
     }),
     getMyWishlist(),

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -15,13 +15,7 @@ interface ProductListContainerProps {
   }>;
 }
 
-const PRICE_OPTIONS = [
-  '5만원 이하',
-  '5-10만원',
-  '10-15만원',
-  '15-20만원',
-  '20만원 이상',
-] as const;
+const PRICE_RANGE_PATTERN = /^\d+-\d+$/;
 
 function normalizeArray(value?: string | string[]) {
   if (Array.isArray(value)) {
@@ -31,6 +25,13 @@ function normalizeArray(value?: string | string[]) {
     return [value];
   }
   return [];
+}
+
+function normalizePriceRange(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value[0] ?? '';
+  }
+  return value ?? '';
 }
 
 export default async function ProductListContainer({
@@ -56,9 +57,10 @@ export default async function ProductListContainer({
   const safeClothingSize = normalizeArray(clothingSize).filter((size) =>
     ['XS', 'S', 'M', 'L', 'XL'].includes(size),
   );
-  const safePriceRange = normalizeArray(priceRange).filter((price) =>
-    PRICE_OPTIONS.includes(price as (typeof PRICE_OPTIONS)[number]),
-  );
+  const rawPriceRange = normalizePriceRange(priceRange);
+  const safePriceRange = PRICE_RANGE_PATTERN.test(rawPriceRange)
+    ? rawPriceRange
+    : '';
 
   // subCategoryId 유효성 검증
   const parsedCategoryId = Number(subCategoryId);
@@ -79,7 +81,7 @@ export default async function ProductListContainer({
         page: safePage,
         size: 36,
         clothingSize: safeClothingSize.length > 0 ? safeClothingSize : undefined,
-        priceRange: safePriceRange.length > 0 ? safePriceRange : undefined,
+        priceRange: safePriceRange || undefined,
         // 1차 구현에서는 brandId 연동 없이 브랜드 UI/URL 상태만 제공합니다.
       },
     }),


### PR DESCRIPTION
## 📝 개요

카테고리 상품 목록 필터 UI를 바텀시트 기반으로 확장하고, API 파라미터를 백엔드 스펙(`brandIds`, `clothingSizes`, `priceRange=min-max`)에 맞게 정렬했습니다.

## 🚀 주요 변경 사항

- [x] `정렬/사이즈/브랜드/가격` 필터 칩 + 바텀시트 UI 구현
- [x] 적용된 필터 태그(칩) 노출 및 개별 해제 동작 추가
- [x] 가격 필터를 단일 선택 + 직접입력(`min-max`) 방식으로 변경
- [x] 카테고리 목록 API 요청 파라미터를 `brandIds`, `clothingSizes`, `priceRange` 형식으로 변경
- [x] 페이지/컨테이너/필터바 간 `searchParams` 타입 및 쿼리 동기화 로직 정리

## 📸 스크린샷 (선택)

|       기능 구현 화면       |
| :------------------------: |
| 사진을 여기에 드래그하세요 |

## ✅ 체크리스트

- [x] 빌드 테스트를 완료했나요? (`pnpm -s exec tsc --noEmit`)
- [x] 코드 컨벤션을 준수했나요?
- [x] 불필요한 console.log는 제거했나요?
