### PR TITLE
feat: 카테고리/검색 필터 UX 및 검색 플로우 개선

### DIFF
--- a/src/app/actions/category.ts
+++ b/src/app/actions/category.ts
@@ -36,7 +36,7 @@ export async function getSubCategories(
 
 /** 추천 하위 카테고리 조회 */
 export async function getRecommendedSubCategories(
-  count = 8,
+  count = 4,
 ): Promise<CategorySimple[]> {
   try {
     return await api.get<CategorySimple[]>('/categories/recommended-sub', {

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -10,7 +10,14 @@ export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 
 interface SearchPageProps {
-  searchParams: Promise<{ q?: string }>;
+  searchParams: Promise<{
+    q?: string;
+    sortType?: string;
+    page?: string;
+    clothingSizes?: string | string[];
+    priceRange?: string | string[];
+    brandIds?: string | string[];
+  }>;
 }
 
 export default async function SearchPage({ searchParams }: SearchPageProps) {
@@ -25,7 +32,7 @@ export default async function SearchPage({ searchParams }: SearchPageProps) {
           <SearchEmpty />
         ) : (
           <Suspense fallback={<SearchLoading />}>
-            <SearchContent query={query} />
+            <SearchContent query={query} searchParams={params} />
           </Suspense>
         )}
       </div>

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -12,6 +12,7 @@ export const revalidate = 0;
 interface SearchPageProps {
   searchParams: Promise<{
     q?: string;
+    searchType?: string;
     sortType?: string;
     page?: string;
     clothingSizes?: string | string[];

--- a/src/app/search/search-content.tsx
+++ b/src/app/search/search-content.tsx
@@ -1,10 +1,11 @@
 import { api } from '@/lib/api-client';
-import { VoiceSearchResponse } from '@/types/domain/product';
+import { ProductSearchResult, VoiceSearchResponse } from '@/types/domain/product';
 import { ProductSortType } from '@/types/enums';
 import { SearchResults } from './search-results';
 import { SearchError } from './search-error';
 
 interface SearchFilterParams {
+  searchType?: string;
   sortType?: string;
   page?: string;
   clothingSizes?: string | string[];
@@ -93,6 +94,60 @@ async function fetchVoiceSearchResults(
   );
 }
 
+async function fetchProductSearchResults(
+  query: string,
+  filters: SearchFilterParams,
+): Promise<VoiceSearchResponse> {
+  const {
+    safeSortType,
+    safePage,
+    safeClothingSizes,
+    safeBrandIds,
+    safePriceRange,
+  } = normalizeFilters(filters);
+
+  const searchResult = await api.get<ProductSearchResult>('/products', {
+    params: {
+      query,
+      sortType: safeSortType,
+      page: safePage,
+      size: 20,
+      clothingSizes:
+        safeClothingSizes.length > 0 ? safeClothingSizes : undefined,
+      priceRange: safePriceRange || undefined,
+      brandIds: safeBrandIds.length > 0 ? safeBrandIds : undefined,
+    },
+    cache: 'no-store',
+  });
+
+  return {
+    extractedKeyword: query,
+    searchResult,
+  };
+}
+
+function shouldUseVoiceEndpoint(filters: SearchFilterParams) {
+  if (filters.searchType !== 'VOICE') {
+    return false;
+  }
+
+  const {
+    safeSortType,
+    safePage,
+    safeClothingSizes,
+    safeBrandIds,
+    safePriceRange,
+  } = normalizeFilters(filters);
+
+  return (
+    safeSortType === ProductSortType.POPULAR &&
+    safePage === '0' &&
+    safeClothingSizes.length === 0 &&
+    safeBrandIds.length === 0 &&
+    safePriceRange.length === 0
+  );
+}
+
 interface SearchContentProps {
   query: string;
   searchParams: SearchFilterParams;
@@ -103,7 +158,9 @@ export async function SearchContent({ query, searchParams }: SearchContentProps)
   let error: Error | null = null;
 
   try {
-    data = await fetchVoiceSearchResults(query, searchParams);
+    data = shouldUseVoiceEndpoint(searchParams)
+      ? await fetchVoiceSearchResults(query, searchParams)
+      : await fetchProductSearchResults(query, searchParams);
   } catch (err) {
     error = err as Error;
   }

--- a/src/app/search/search-content.tsx
+++ b/src/app/search/search-content.tsx
@@ -1,18 +1,92 @@
 import { api } from '@/lib/api-client';
 import { VoiceSearchResponse } from '@/types/domain/product';
+import { ProductSortType } from '@/types/enums';
 import { SearchResults } from './search-results';
 import { SearchError } from './search-error';
 
-async function fetchSearchResults(query: string): Promise<VoiceSearchResponse> {
+interface SearchFilterParams {
+  sortType?: string;
+  page?: string;
+  clothingSizes?: string | string[];
+  priceRange?: string | string[];
+  brandIds?: string | string[];
+}
+
+const PRICE_RANGE_PATTERN = /^\d+-\d+$/;
+
+function normalizeArray(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value.filter((item) => item.trim().length > 0);
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return [value];
+  }
+  return [];
+}
+
+function normalizePriceRange(value?: string | string[]) {
+  if (Array.isArray(value)) {
+    return value[0] ?? '';
+  }
+  return value ?? '';
+}
+
+function normalizeFilters(filters: SearchFilterParams) {
+  const sortValues = Object.values(ProductSortType);
+  const safeSortType = sortValues.includes(filters.sortType as ProductSortType)
+    ? (filters.sortType as ProductSortType)
+    : ProductSortType.POPULAR;
+  const safePage =
+    Number.isFinite(Number(filters.page)) && Number(filters.page) >= 0
+      ? String(Number(filters.page))
+      : '0';
+  const safeClothingSizes = normalizeArray(filters.clothingSizes).filter((size) =>
+    ['XS', 'S', 'M', 'L', 'XL'].includes(size),
+  );
+  const safeBrandIds = normalizeArray(filters.brandIds).filter((value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) && parsed > 0;
+  });
+  const rawPriceRange = normalizePriceRange(filters.priceRange);
+  const safePriceRange = PRICE_RANGE_PATTERN.test(rawPriceRange)
+    ? rawPriceRange
+    : '';
+
+  return {
+    safeSortType,
+    safePage,
+    safeClothingSizes,
+    safeBrandIds,
+    safePriceRange,
+  };
+}
+
+async function fetchVoiceSearchResults(
+  query: string,
+  filters: SearchFilterParams,
+): Promise<VoiceSearchResponse> {
+  const {
+    safeSortType,
+    safePage,
+    safeClothingSizes,
+    safeBrandIds,
+    safePriceRange,
+  } = normalizeFilters(filters);
+
   return await api.post<VoiceSearchResponse>(
     '/search/voice',
     {}, // Empty body - params are in query string
     {
       params: {
         speechText: query,
-        page: '0',
+        sortType: safeSortType,
+        sort: JSON.stringify([safeSortType]),
+        page: safePage,
         size: '20',
-        sort: JSON.stringify(['string']),
+        clothingSizes:
+          safeClothingSizes.length > 0 ? safeClothingSizes : undefined,
+        priceRange: safePriceRange || undefined,
+        brandIds: safeBrandIds.length > 0 ? safeBrandIds : undefined,
       },
       cache: 'no-store',
     },
@@ -21,14 +95,15 @@ async function fetchSearchResults(query: string): Promise<VoiceSearchResponse> {
 
 interface SearchContentProps {
   query: string;
+  searchParams: SearchFilterParams;
 }
 
-export async function SearchContent({ query }: SearchContentProps) {
+export async function SearchContent({ query, searchParams }: SearchContentProps) {
   let data: VoiceSearchResponse | null = null;
   let error: Error | null = null;
 
   try {
-    data = await fetchSearchResults(query);
+    data = await fetchVoiceSearchResults(query, searchParams);
   } catch (err) {
     error = err as Error;
   }

--- a/src/app/search/search-results.tsx
+++ b/src/app/search/search-results.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import ProductList from '@/components/product/product-list';
+import { ProductFilterBar, type BrandFilterOption } from '@/components/product/product-filter-bar';
 
 import { VoiceSearchResponse } from '@/types/domain/product';
 import { useRecentSearches } from '@/components/search-bar/use-recent-searches';
@@ -30,6 +31,29 @@ export function SearchResults({ data, query }: SearchResultsProps) {
     data.extractedKeyword,
     query,
   );
+  const availableBrands = useMemo(() => {
+    const products = data.searchResult.products.content as Array<{
+      brandId?: number;
+      brandName: string;
+    }>;
+
+    return Array.from(
+      new Map(
+        products
+          .map((product) => {
+            const id = Number(product.brandId);
+            const name = product.brandName.trim();
+            if (!Number.isFinite(id) || id <= 0 || name.length === 0) return null;
+            return [String(id), { id, name }] as const;
+          })
+          .filter(
+            (
+              item,
+            ): item is readonly [string, BrandFilterOption] => item !== null,
+          ),
+      ).values(),
+    ).sort((a, b) => a.name.localeCompare(b.name, 'ko'));
+  }, [data.searchResult.products.content]);
 
   // Save the extracted keyword to recent searches
   useEffect(() => {
@@ -110,6 +134,8 @@ export function SearchResults({ data, query }: SearchResultsProps) {
           <p className="mt-2 text-sm text-gray-500">원래 검색어: {query}</p>
         )}
       </div>
+
+      <ProductFilterBar parentCategoryName="" availableBrands={availableBrands} />
 
       {/* Search results */}
       {hasResult && products.length > 0 ? (

--- a/src/components/product/product-filter-bar-container.tsx
+++ b/src/components/product/product-filter-bar-container.tsx
@@ -1,6 +1,5 @@
 import { getSubCategories } from '@/app/actions/category';
 import { api } from '@/lib/api-client';
-import { BrandWithProducts } from '@/types/domain/brand';
 import { ProductSearchResult } from '@/types/domain/product';
 import { ProductSortType } from '@/types/enums';
 import { BrandFilterOption, ProductFilterBar } from './product-filter-bar';
@@ -17,10 +16,6 @@ interface ProductFilterBarContainerProps {
 }
 
 const PRICE_RANGE_PATTERN = /^\d+-\d+$/;
-
-function normalizeBrandName(value: string) {
-  return value.trim().toLowerCase().replace(/\s+/g, '');
-}
 
 function normalizeArray(value?: string | string[]) {
   if (Array.isArray(value)) {
@@ -94,50 +89,20 @@ export default async function ProductFilterBarContainer({
     brandName: string;
     brandId?: number;
   }>;
-  const brandsFromProducts = Array.from(
-    new Set(
-      productItems
-        .map((product) => product.brandName.trim())
-        .filter((brandName) => brandName.length > 0),
-    ),
-  );
-
-  const recommendedBrands = await api
-    .get<BrandWithProducts[]>('/brands/recommend', { params: { count: 200 } })
-    .catch(() => []);
-
-  const brandIdByNormalizedName = new Map<string, number>();
-  productItems.forEach((product) => {
-    const normalized = normalizeBrandName(product.brandName);
-    if (!normalized) return;
-    if (Number.isFinite(product.brandId) && (product.brandId as number) > 0) {
-      brandIdByNormalizedName.set(normalized, product.brandId as number);
-    }
-  });
-  recommendedBrands.forEach((brand) => {
-    const normalized = normalizeBrandName(brand.name);
-    if (!normalized || brandIdByNormalizedName.has(normalized)) return;
-    brandIdByNormalizedName.set(normalized, brand.id);
-  });
-
-  const mappedFromProducts = brandsFromProducts
-    .map((name) => {
-      const id = brandIdByNormalizedName.get(normalizeBrandName(name));
-      if (!id) return null;
-      return { id, name };
-    })
-    .filter((item): item is BrandFilterOption => item !== null);
-
-  const mappedFromRecommended: BrandFilterOption[] = recommendedBrands.map(
-    (brand) => ({ id: brand.id, name: brand.name }),
-  );
-
   const availableBrands = Array.from(
     new Map(
-      [...mappedFromProducts, ...mappedFromRecommended].map((brand) => [
-        String(brand.id),
-        brand,
-      ]),
+      productItems
+        .map((product) => {
+          const id = Number(product.brandId);
+          const name = product.brandName.trim();
+          if (!Number.isFinite(id) || id <= 0 || name.length === 0) return null;
+          return [String(id), { id, name }] as const;
+        })
+        .filter(
+          (
+            item,
+          ): item is readonly [string, BrandFilterOption] => item !== null,
+        ),
     ).values(),
   ).sort((a, b) => a.name.localeCompare(b.name, 'ko'));
 

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { X } from 'lucide-react';
 import { ProductSortType } from '@/types/enums';
 
 type FilterTab = 'size' | 'brand' | 'price';
@@ -552,7 +553,7 @@ export function ProductFilterBar({
               <div className="min-h-[290px] px-4 pt-4 pb-5">{renderFilterContent()}</div>
 
               <div className="border-t border-gray-200 px-4 pt-3 pb-4">
-                <div className="mb-3 flex min-h-11 flex-wrap gap-2">
+                <div className="mb-3 flex min-h-11 flex-wrap items-center gap-2">
                   {tempChips.map((chip) => (
                     <button
                       key={`temp-${chip.key}-${chip.value}`}
@@ -572,10 +573,12 @@ export function ProductFilterBar({
                           prev.filter((item) => item !== chip.value),
                         );
                       }}
-                      className="border-ongil-teal bg-ongil-mint/50 text-ongil-teal inline-flex items-center gap-2 rounded-xl border px-3 py-1 text-sm font-medium"
+                      className="border-ongil-teal bg-ongil-mint/50 text-ongil-teal relative inline-flex items-center justify-center rounded-xl border px-10 py-2 text-[20px] font-medium"
                     >
-                      {chip.label}
-                      <span className="text-xs">x</span>
+                      <span className="text-center leading-none">{chip.label}</span>
+                      <span className="absolute top-1/2 right-3 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full border border-ongil-teal bg-white">
+                        <X className="h-4 w-4" strokeWidth={2.5} aria-hidden="true" />
+                      </span>
                     </button>
                   ))}
                 </div>

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -225,7 +225,7 @@ export function ProductFilterBar({
               >
                 <div className="flex flex-col items-center leading-tight">
                   <span className="text-lg font-semibold">{option.label}</span>
-                  <span className="mt-1 text-sm font-medium text-gray-500">
+                  <span className="mt-1 text-[18px] font-semibold text-gray-500">
                     ({option.description})
                   </span>
                 </div>

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -17,12 +17,6 @@ interface ProductFilterBarProps {
   availableBrands: BrandFilterOption[];
 }
 
-interface ChipItem {
-  key: 'clothingSizes' | 'priceRange' | 'brandIds';
-  value: string;
-  label: string;
-}
-
 const SORT_OPTIONS: { value: ProductSortType; label: string }[] = [
   { value: ProductSortType.POPULAR, label: '인기순' },
   { value: ProductSortType.REVIEW, label: '리뷰 많은순' },
@@ -63,16 +57,6 @@ function toggleValue(items: string[], value: string) {
 function setRepeatedQuery(params: URLSearchParams, key: string, values: string[]) {
   params.delete(key);
   values.forEach((value) => params.append(key, value));
-}
-
-function removeOneMultiFilterValue(
-  params: URLSearchParams,
-  key: 'clothingSizes' | 'brandIds',
-  value: string,
-) {
-  const nextValues = params.getAll(key).filter((item) => item !== value);
-  params.delete(key);
-  nextValues.forEach((item) => params.append(key, item));
 }
 
 function normalizeNumberInput(value: string) {
@@ -152,28 +136,9 @@ export function ProductFilterBar({
 
   const currentSortLabel =
     SORT_OPTIONS.find((option) => option.value === currentSort)?.label || '인기순';
-
-  const appliedChips: ChipItem[] = [
-    ...selectedSizes.map((value) => ({
-      key: 'clothingSizes' as const,
-      value,
-      label: value,
-    })),
-    ...(selectedPriceRange
-      ? [
-          {
-            key: 'priceRange' as const,
-            value: selectedPriceRange,
-            label: getPriceRangeLabel(selectedPriceRange),
-          },
-        ]
-      : []),
-    ...selectedBrandIds.map((value) => ({
-      key: 'brandIds' as const,
-      value,
-      label: getBrandLabelById(value, mergedBrandOptions, selectedBrandIds),
-    })),
-  ];
+  const hasSizeFilter = selectedSizes.length > 0;
+  const hasBrandFilter = selectedBrandIds.length > 0;
+  const hasPriceFilter = Boolean(selectedPriceRange);
 
   const tempChips = [
     ...tempSizes.map((value) => ({
@@ -237,17 +202,6 @@ export function ProductFilterBar({
     }
     navigateWithParams(params);
     setOpenSheet(null);
-  };
-
-  const handleRemoveChip = (chip: ChipItem) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (chip.key === 'priceRange') {
-      params.delete('priceRange');
-      navigateWithParams(params);
-      return;
-    }
-    removeOneMultiFilterValue(params, chip.key, chip.value);
-    navigateWithParams(params);
   };
 
   const renderFilterContent = () => {
@@ -421,7 +375,7 @@ export function ProductFilterBar({
 
   return (
     <>
-      <div className="mb-3 overflow-x-auto pb-1">
+      <div className="mt-5 mb-3 overflow-x-auto pb-1">
         <div className="flex w-max items-center gap-2">
           <button
             type="button"
@@ -442,7 +396,9 @@ export function ProductFilterBar({
           <button
             type="button"
             onClick={() => openFilterSheet('size')}
-            className="border-ongil-teal text-ongil-teal h-10 rounded-full border bg-white px-4 text-base font-semibold"
+            className={`border-ongil-teal text-ongil-teal h-10 rounded-full border px-4 text-base font-semibold ${
+              hasSizeFilter ? 'bg-ongil-mint' : 'bg-white'
+            }`}
           >
             사이즈{selectedSizes.length > 0 ? selectedSizes.length : ''}
           </button>
@@ -450,7 +406,9 @@ export function ProductFilterBar({
           <button
             type="button"
             onClick={() => openFilterSheet('brand')}
-            className="border-ongil-teal text-ongil-teal h-10 rounded-full border bg-white px-4 text-base font-semibold"
+            className={`border-ongil-teal text-ongil-teal h-10 rounded-full border px-4 text-base font-semibold ${
+              hasBrandFilter ? 'bg-ongil-mint' : 'bg-white'
+            }`}
           >
             브랜드{selectedBrandIds.length > 0 ? selectedBrandIds.length : ''}
           </button>
@@ -458,28 +416,14 @@ export function ProductFilterBar({
           <button
             type="button"
             onClick={() => openFilterSheet('price')}
-            className="border-ongil-teal text-ongil-teal h-10 rounded-full border bg-white px-4 text-base font-semibold"
+            className={`border-ongil-teal text-ongil-teal h-10 rounded-full border px-4 text-base font-semibold ${
+              hasPriceFilter ? 'bg-ongil-mint' : 'bg-white'
+            }`}
           >
             가격{selectedPriceRange ? '1' : ''}
           </button>
         </div>
       </div>
-
-      {appliedChips.length > 0 && (
-        <div className="mb-4 flex flex-wrap gap-2">
-          {appliedChips.map((chip) => (
-            <button
-              key={`${chip.key}-${chip.value}`}
-              type="button"
-              onClick={() => handleRemoveChip(chip)}
-              className="border-ongil-teal bg-ongil-mint/50 text-ongil-teal inline-flex items-center gap-2 rounded-xl border px-3 py-1.5 text-sm font-medium"
-            >
-              {chip.label}
-              <span className="text-xs">x</span>
-            </button>
-          ))}
-        </div>
-      )}
 
       {openSheet === 'sort' && (
         <>

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -434,10 +434,10 @@ export function ProductFilterBar({
       {openSheet === 'sort' && (
         <>
           <div
-            className="fixed inset-0 z-50 bg-black/10"
+            className="fixed inset-0 z-[70] bg-black/10"
             onClick={() => setOpenSheet(null)}
           />
-          <div className="fixed inset-x-0 bottom-0 z-50 rounded-t-[22px] bg-white px-6 pt-6 pb-10 shadow-[0_-6px_20px_rgba(0,0,0,0.08)]">
+          <div className="fixed inset-x-0 bottom-0 z-[71] rounded-t-[22px] bg-white px-6 pt-6 pb-10 shadow-[0_-6px_20px_rgba(0,0,0,0.08)]">
             <div className="mx-auto w-full max-w-7xl">
               <div className="relative mb-8 flex items-center justify-center">
                 <h3 className="text-2xl font-bold text-black">정렬</h3>
@@ -504,10 +504,10 @@ export function ProductFilterBar({
       {openSheet === 'filters' && (
         <>
           <div
-            className="fixed inset-0 z-50 bg-black/10"
+            className="fixed inset-0 z-[70] bg-black/10"
             onClick={() => setOpenSheet(null)}
           />
-          <div className="fixed inset-x-0 bottom-0 z-50 rounded-t-[22px] bg-white shadow-[0_-6px_20px_rgba(0,0,0,0.08)]">
+          <div className="fixed inset-x-0 bottom-0 z-[71] rounded-t-[22px] bg-white shadow-[0_-6px_20px_rgba(0,0,0,0.08)]">
             <div className="mx-auto w-full max-w-7xl">
               <div className="relative flex items-center justify-end px-4 pt-4 pb-2">
                 <button

--- a/src/components/product/product-filter-bar.tsx
+++ b/src/components/product/product-filter-bar.tsx
@@ -216,14 +216,19 @@ export function ProductFilterBar({
                 key={option.value}
                 type="button"
                 onClick={() => setTempSizes((prev) => toggleValue(prev, option.value))}
-                className={`rounded-xl border px-4 py-3 text-center text-base font-semibold transition-colors ${
+                className={`rounded-xl border px-4 py-3 text-center transition-colors ${
                   isSelected
                     ? 'border-ongil-teal bg-ongil-mint text-black'
                     : 'border-gray-300 bg-white text-gray-900'
                 }`}
                 title={option.description}
               >
-                {option.label}
+                <div className="flex flex-col items-center leading-tight">
+                  <span className="text-lg font-semibold">{option.label}</span>
+                  <span className="mt-1 text-sm font-medium text-gray-500">
+                    ({option.description})
+                  </span>
+                </div>
               </button>
             );
           })}

--- a/src/components/product/product-list-container.tsx
+++ b/src/components/product/product-list-container.tsx
@@ -104,12 +104,26 @@ export default async function ProductListContainer({
   }));
 
   const totalElements = result.products.totalElements;
+  const detailFromParams = new URLSearchParams();
+  detailFromParams.set('sortType', safeSortType);
+  detailFromParams.set('page', String(safePage));
+  safeClothingSizes.forEach((size) =>
+    detailFromParams.append('clothingSizes', size),
+  );
+  safeBrandIds.forEach((brandId) => detailFromParams.append('brandIds', brandId));
+  if (safePriceRange) {
+    detailFromParams.set('priceRange', safePriceRange);
+  }
+  const detailFromQuery = detailFromParams.toString();
+  const productDetailFrom = detailFromQuery
+    ? `/category/${parentId}/${subCategoryId}?${detailFromQuery}`
+    : `/category/${parentId}/${subCategoryId}`;
 
   return (
     <ProductList
       products={productsWithWishlist}
       totalElements={totalElements}
-      productDetailFrom={`/category/${parentId}/${subCategoryId}`}
+      productDetailFrom={productDetailFrom}
       showWishlistButton
     />
   );

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState, useRef } from 'react';
-import { useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { X } from 'lucide-react';
 import { VoiceOverlay } from './voice-overlay';
 import { useRecentSearches } from './use-recent-searches';
@@ -20,6 +20,7 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
+  const searchParams = useSearchParams();
 
   const { history, addSearch, removeSearch, clearHistory, refreshHistory } =
     useRecentSearches();
@@ -73,6 +74,11 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
     setIsVoiceActive(true);
     updateFocus(false);
   };
+
+  useEffect(() => {
+    const nextQuery = searchParams.get('q') ?? '';
+    setQuery(nextQuery);
+  }, [searchParams]);
 
   return (
     <div className="relative z-110 flex-1">

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -36,8 +36,9 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
     onFocusChange?.(focused);
   };
 
-  const navigateToSearch = (keyword: string) => {
-    const searchUrl = `/search?q=${encodeURIComponent(keyword)}`;
+  const navigateToSearch = (keyword: string, isVoiceSearch = false) => {
+    const searchTypeQuery = isVoiceSearch ? '&searchType=VOICE' : '';
+    const searchUrl = `/search?q=${encodeURIComponent(keyword)}${searchTypeQuery}`;
     router.push(searchUrl);
     router.refresh(); // Force refresh to trigger server component re-render
   };
@@ -48,7 +49,7 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
     inputRef.current?.blur();
     updateFocus(false);
     addSearch(keyword);
-    navigateToSearch(keyword);
+    navigateToSearch(keyword, false);
   };
 
   const handleVoiceSearchResult = (text: string) => {
@@ -57,7 +58,7 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
     inputRef.current?.blur();
     updateFocus(false);
     // Voice input should be stored after keyword extraction in search results page.
-    navigateToSearch(keyword);
+    navigateToSearch(keyword, true);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/search-bar/search-bar.tsx
+++ b/src/components/search-bar/search-bar.tsx
@@ -36,17 +36,28 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
     onFocusChange?.(focused);
   };
 
+  const navigateToSearch = (keyword: string) => {
+    const searchUrl = `/search?q=${encodeURIComponent(keyword)}`;
+    router.push(searchUrl);
+    router.refresh(); // Force refresh to trigger server component re-render
+  };
+
   const handleSearch = (text: string) => {
     const keyword = text.trim();
     if (!keyword) return;
     inputRef.current?.blur();
     updateFocus(false);
     addSearch(keyword);
+    navigateToSearch(keyword);
+  };
 
-    // Navigate to search results page
-    const searchUrl = `/search?q=${encodeURIComponent(keyword)}`;
-    router.push(searchUrl);
-    router.refresh(); // Force refresh to trigger server component re-render
+  const handleVoiceSearchResult = (text: string) => {
+    const keyword = text.trim();
+    if (!keyword) return;
+    inputRef.current?.blur();
+    updateFocus(false);
+    // Voice input should be stored after keyword extraction in search results page.
+    navigateToSearch(keyword);
   };
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -67,7 +78,7 @@ export default function SearchBar({ onFocusChange }: SearchBarProps) {
       {isVoiceActive && (
         <VoiceOverlay
           onClose={() => setIsVoiceActive(false)}
-          onFinalResult={(text) => handleSearch(text)}
+          onFinalResult={handleVoiceSearchResult}
         />
       )}
 


### PR DESCRIPTION
## 작업 내용\n- 카테고리 필터바 하단 선택 칩 제거\n- 활성 필터 버튼(사이즈/브랜드/가격) 민트 배경 처리\n- 필터바 상단 여백 및 바텀시트 칩 UI 개선\n- 상세 페이지 뒤로가기 시 카테고리 필터 상태 유지\n- 브랜드 필터 소스를 카테고리 상품의 brandId/brandName 기준으로 정리\n- 음성검색 최근검색어 저장 기준을 추출 키워드로 정리\n- 검색 페이지에 필터 파라미터 전달 구조 정리\n- 검색바에 현재 q 쿼리 자동 반영\n\n## 참고\n- 사용자 로컬 변경(src/components/mypage/profile-section.tsx)은 PR에 포함하지 않았습니다.